### PR TITLE
Make IPv6 Great Again

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1027,6 +1027,10 @@ func (ep *endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 			ep.Unlock()
 			return nil
 		}
+		if err == ipamapi.ErrNoIPReturned {
+			// No IP was returned intentionally, don't treat as error
+			return nil
+		}
 		if err != ipamapi.ErrNoAvailableIPs || progAdd != nil {
 			return err
 		}

--- a/network.go
+++ b/network.go
@@ -1235,7 +1235,7 @@ func (n *network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 	}
 
 	if len(*cfgList) == 0 {
-		if ipVer == 6 {
+		if ipVer == 6 && !n.enableIPv6 {
 			return nil
 		}
 		*cfgList = []*IpamConf{{}}


### PR DESCRIPTION
This makes IPv6 a proper citizen by:
- Allowing an endpoint to have only an IPv6 address if network.enableIPv6 is set.
- Enabling allocation of an IPv6 address if netlabel.EnableIPv6 is set even without the presence of a network.ipamV6Conf.

Existing IPv4 behaviour is kept intact: Unless network.enableIPv6 is explicitly set by the user, an IPv4 configuration failure is considered fatal even in the presence of a working IPv6 configuration.
