### PR TITLE
Allow Docker daemon to bind to different IP than --cluster-advertise.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,10 +36,11 @@ type DaemonCfg struct {
 
 // ClusterCfg represents cluster configuration
 type ClusterCfg struct {
-	Watcher   discovery.Watcher
-	Address   string
-	Discovery string
-	Heartbeat uint64
+	Watcher     discovery.Watcher
+	Address     string
+	BindAddress string
+	Discovery   string
+	Heartbeat   uint64
 }
 
 // LoadDefaultScopes loads default scope configs for scopes which
@@ -188,6 +189,13 @@ func OptionDiscoveryWatcher(watcher discovery.Watcher) Option {
 func OptionDiscoveryAddress(address string) Option {
 	return func(c *Config) {
 		c.Cluster.Address = address
+	}
+}
+
+// OptionDiscoveryBindAddress function returns an option setter for self discovery bind address
+func OptionDiscoveryBindAddress(address string) Option {
+	return func(c *Config) {
+		c.Cluster.BindAddress = address
 	}
 }
 

--- a/controller.go
+++ b/controller.go
@@ -504,10 +504,16 @@ func (c *controller) processNodeDiscovery(nodes []net.IP, add bool) {
 }
 
 func (c *controller) pushNodeDiscovery(d driverapi.Driver, cap driverapi.Capability, nodes []net.IP, add bool) {
-	var self net.IP
+	var self, bind net.IP
 	if c.cfg != nil {
 		addr := strings.Split(c.cfg.Cluster.Address, ":")
 		self = net.ParseIP(addr[0])
+		if len(c.cfg.Cluster.BindAddress) != 0 {
+			addr = strings.Split(c.cfg.Cluster.BindAddress, ":")
+			bind = net.ParseIP(addr[0])
+		} else {
+			bind = self
+		}
 	}
 
 	if d == nil || cap.DataScope != datastore.GlobalScope || nodes == nil {
@@ -515,7 +521,10 @@ func (c *controller) pushNodeDiscovery(d driverapi.Driver, cap driverapi.Capabil
 	}
 
 	for _, node := range nodes {
-		nodeData := discoverapi.NodeDiscoveryData{Address: node.String(), Self: node.Equal(self)}
+		if !node.Equal(self) {
+			bind = node
+		}
+		nodeData := discoverapi.NodeDiscoveryData{Address: node.String(), BindAddress: bind.String(), Self: node.Equal(self)}
 		var err error
 		if add {
 			err = d.DiscoverNew(discoverapi.NodeDiscovery, nodeData)

--- a/drivers/overlay/ov_serf.go
+++ b/drivers/overlay/ov_serf.go
@@ -40,7 +40,8 @@ func (d *driver) serfInit() error {
 
 	config := serf.DefaultConfig()
 	config.Init()
-	config.MemberlistConfig.BindAddr = d.advertiseAddress
+	config.MemberlistConfig.BindAddr = d.bindAddress
+	config.MemberlistConfig.AdvertiseAddr = d.advertiseAddress
 
 	d.eventCh = make(chan serf.Event, 4)
 	config.EventCh = d.eventCh

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -198,10 +198,14 @@ func (d *driver) Type() string {
 	return networkType
 }
 
-func validateSelf(node string) error {
+func validateSelfAndBind(node, bind string) error {
 	advIP := net.ParseIP(node)
 	if advIP == nil {
 		return fmt.Errorf("invalid self address (%s)", node)
+	}
+	advIP = net.ParseIP(bind)
+	if advIP == nil {
+		return fmt.Errorf("invalid self bind address (%s)", bind)
 	}
 
 	addrs, err := net.InterfaceAddrs()
@@ -214,7 +218,10 @@ func validateSelf(node string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Multi-Host overlay networking requires cluster-advertise(%s) to be configured with a local ip-address that is reachable within the cluster", advIP.String())
+	if net.ParseIP("0.0.0.0").Equal(advIP) {
+		return nil
+	}
+	return fmt.Errorf("Multi-Host overlay networking requires cluster-listen(%s) to be configured with a local ip-address that is reachable within the cluster", advIP.String())
 }
 
 func (d *driver) nodeJoin(advertiseAddress, bindAddress string, self bool) {
@@ -226,7 +233,7 @@ func (d *driver) nodeJoin(advertiseAddress, bindAddress string, self bool) {
 
 		// If there is no cluster store there is no need to start serf.
 		if d.store != nil {
-			if err := validateSelf(advertiseAddress); err != nil {
+			if err := validateSelfAndBind(advertiseAddress, bindAddress); err != nil {
 				logrus.Warnf("%s", err.Error())
 			}
 			err := d.serfInit()

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -46,7 +46,7 @@ func setupDriver(t *testing.T) *driverTester {
 		t.Fatal(err)
 	}
 	data := discoverapi.NodeDiscoveryData{
-		Address: addrs[0].String(),
+		Address: addrs[0].(*net.IPNet).IP.String(),
 		Self:    true,
 	}
 	dt.d.DiscoverNew(discoverapi.NodeDiscovery, data)


### PR DESCRIPTION
This fix intends to address the issue raised in

https://github.com/docker/docker/issues/22008
https://github.com/docker/docker/issues/22087

where Docker's overlay networking can only bind to the IP specified in the option of `--cluster-advertise`. In certain situations, end user may want the overlay networking to bind to an internal IP while at the same
time advertise a publicly accessible IP.

This fix is to eventually address the pull request in:

https://github.com/docker/docker/pull/22663

where an additional option of --cluster-listen has been added to allow passing a differnt IP than --cluster-advertise.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
