### PR TITLE
Reduce downtime after LB backend removal

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -644,6 +644,12 @@ func fwMarker() {
 				logrus.Errorf("Failed to write to /proc/sys/net/ipv4/vs/conntrack: %v", err)
 				os.Exit(8)
 			}
+
+			err = ioutil.WriteFile("/proc/sys/net/ipv4/vs/expire_nodest_conn", []byte{'1', '\n'}, 0644)
+			if err != nil {
+				logrus.Errorf("Failed to write to /proc/sys/net/ipv4/vs/expire_nodest_conn: %v", err)
+				os.Exit(10)
+			}
 		}
 	}
 


### PR DESCRIPTION
When an LB backend is removed and the corresponding ipvs destination is
deleted, ipvs maintains dangling connections pointing to the destination
if the connections have existed since before destination removal.
Then packets going to this connection will be dropped in kernel because
there is no destination with this connection. This continues until the
connection expires (e.g. 60 seconds for SYN_RECV (tcp initial) state).
This in some cases causes TCP connection timeout if the connection is
initiated between container failure and ipvs destination deletion.

ipvs provides a parameter "expire_nodest_conn" to reduce the downtime.
When enabling the option, the staled connection immediately expires on
receiving a packet on the connection.

Although this option is not suitable if flapping can happen, I think the
user of LB should ensure it not to happen by taking enough time before
determining the container is unreachable.

Reference: https://www.kernel.org/doc/Documentation/networking/ipvs-sysctl.txt
Signed-off-by: Toshiaki Makita <makita.toshiaki@lab.ntt.co.jp>