### PR TITLE
Some portmapper cleanup

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -648,7 +648,7 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 		id:         config.ID,
 		endpoints:  make(map[string]*bridgeEndpoint),
 		config:     config,
-		portMapper: portmapper.New(portmapper.WithProxyPath(d.config.UserlandProxyPath)),
+		portMapper: portmapper.New(portmapper.WithUserlandProxy(d.config.EnableUserlandProxy, d.config.UserlandProxyPath)),
 		driver:     d,
 	}
 
@@ -1297,7 +1297,7 @@ func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string
 	}
 
 	// Program any required port mapping and store them in the endpoint
-	endpoint.portMapping, err = network.allocatePorts(endpoint, network.config.DefaultBindingIP, d.config.EnableUserlandProxy)
+	endpoint.portMapping, err = network.allocatePorts(endpoint, network.config.DefaultBindingIP)
 	if err != nil {
 		return err
 	}

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -32,7 +32,6 @@ const (
 	vethPrefix                 = "veth"
 	vethLen                    = 7
 	defaultContainerVethPrefix = "eth"
-	maxAllocatePortAttempts    = 10
 )
 
 const (

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -648,7 +648,7 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 		id:         config.ID,
 		endpoints:  make(map[string]*bridgeEndpoint),
 		config:     config,
-		portMapper: portmapper.New(d.config.UserlandProxyPath),
+		portMapper: portmapper.New(portmapper.WithProxyPath(d.config.UserlandProxyPath)),
 		driver:     d,
 	}
 

--- a/drivers/bridge/bridge_store.go
+++ b/drivers/bridge/bridge_store.go
@@ -380,7 +380,7 @@ func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {
 	}
 	tmp := ep.extConnConfig.PortBindings
 	ep.extConnConfig.PortBindings = ep.portMapping
-	_, err := n.allocatePorts(ep, n.config.DefaultBindingIP, n.driver.config.EnableUserlandProxy)
+	_, err := n.allocatePorts(ep, n.config.DefaultBindingIP)
 	if err != nil {
 		logrus.Warnf("Failed to reserve existing port mapping for endpoint %s:%v", ep.id[0:7], err)
 	}

--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -14,7 +14,7 @@ var (
 	defaultBindingIP = net.IPv4(0, 0, 0, 0)
 )
 
-func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
+func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP) ([]types.PortBinding, error) {
 	if ep.extConnConfig == nil || ep.extConnConfig.PortBindings == nil {
 		return nil, nil
 	}
@@ -24,14 +24,14 @@ func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP, u
 		defHostIP = reqDefBindIP
 	}
 
-	return n.allocatePortsInternal(ep.extConnConfig.PortBindings, ep.addr.IP, defHostIP, ulPxyEnabled)
+	return n.allocatePortsInternal(ep.extConnConfig.PortBindings, ep.addr.IP, defHostIP)
 }
 
-func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, containerIP, defHostIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
+func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, containerIP, defHostIP net.IP) ([]types.PortBinding, error) {
 	bs := make([]types.PortBinding, 0, len(bindings))
 	for _, c := range bindings {
 		b := c.GetCopy()
-		if err := n.allocatePort(&b, containerIP, defHostIP, ulPxyEnabled); err != nil {
+		if err := n.allocatePort(&b, containerIP, defHostIP); err != nil {
 			// On allocation failure, release previously allocated ports. On cleanup error, just log a warning message
 			if cuErr := n.releasePortsInternal(bs); cuErr != nil {
 				logrus.Warnf("Upon allocation failure for %v, failed to clear previously allocated port bindings: %v", b, cuErr)
@@ -43,7 +43,7 @@ func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, cont
 	return bs, nil
 }
 
-func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHostIP net.IP, ulPxyEnabled bool) error {
+func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHostIP net.IP) error {
 	var (
 		host net.Addr
 		err  error
@@ -70,7 +70,7 @@ func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHos
 
 	// Try up to maxAllocatePortAttempts times to get a port that's not already allocated.
 	for i := 0; i < maxAllocatePortAttempts; i++ {
-		if host, err = n.portMapper.MapRange(container, bnd.HostIP, int(bnd.HostPort), int(bnd.HostPortEnd), ulPxyEnabled); err == nil {
+		if host, err = n.portMapper.MapRange(container, bnd.HostIP, int(bnd.HostPort), int(bnd.HostPortEnd)); err == nil {
 			break
 		}
 		// There is no point in immediately retrying to map an explicitly chosen port.

--- a/drivers/bridge/setup_ip_tables_test.go
+++ b/drivers/bridge/setup_ip_tables_test.go
@@ -124,7 +124,7 @@ func assertChainConfig(d *driver, t *testing.T) {
 
 // Assert function which pushes chains based on bridge config parameters.
 func assertBridgeConfig(config *networkConfiguration, br *bridgeInterface, d *driver, t *testing.T) {
-	nw := bridgeNetwork{portMapper: portmapper.New(""),
+	nw := bridgeNetwork{portMapper: portmapper.New(),
 		config: config}
 	nw.driver = d
 

--- a/drivers/solaris/bridge/bridge.go
+++ b/drivers/solaris/bridge/bridge.go
@@ -525,7 +525,7 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 		id:         config.ID,
 		endpoints:  make(map[string]*bridgeEndpoint),
 		config:     config,
-		portMapper: portmapper.New(""),
+		portMapper: portmapper.New(),
 		driver:     d,
 	}
 

--- a/drivers/solaris/bridge/port_mapping.go
+++ b/drivers/solaris/bridge/port_mapping.go
@@ -76,7 +76,7 @@ func removePFRules(epid string) {
 	}
 }
 
-func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, bindIntf string, reqDefBindIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
+func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, bindIntf string, reqDefBindIP net.IP) ([]types.PortBinding, error) {
 	if ep.extConnConfig == nil || ep.extConnConfig.PortBindings == nil {
 		return nil, nil
 	}
@@ -86,7 +86,7 @@ func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, bindIntf string, reqDe
 		defHostIP = reqDefBindIP
 	}
 
-	bs, err := n.allocatePortsInternal(ep.extConnConfig.PortBindings, bindIntf, ep.addr.IP, defHostIP, ulPxyEnabled)
+	bs, err := n.allocatePortsInternal(ep.extConnConfig.PortBindings, bindIntf, ep.addr.IP, defHostIP)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, bindIntf string, reqDe
 	return bs, err
 }
 
-func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, bindIntf string, containerIP, defHostIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
+func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, bindIntf string, containerIP, defHostIP net.IP) ([]types.PortBinding, error) {
 	bs := make([]types.PortBinding, 0, len(bindings))
 	for _, c := range bindings {
 		b := c.GetCopy()
@@ -148,7 +148,7 @@ func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHos
 	// not already allocated.
 	for i := 0; i < maxAllocatePortAttempts; i++ {
 		if host, err = n.portMapper.MapRange(container, bnd.HostIP,
-			int(bnd.HostPort), int(bnd.HostPortEnd), false); err == nil {
+			int(bnd.HostPort), int(bnd.HostPortEnd)); err == nil {
 			break
 		}
 		// There is no point in immediately retrying to map an

--- a/drivers/solaris/bridge/port_mapping.go
+++ b/drivers/solaris/bridge/port_mapping.go
@@ -76,7 +76,7 @@ func removePFRules(epid string) {
 	}
 }
 
-func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, bindIntf string, reqDefBindIP net.IP) ([]types.PortBinding, error) {
+func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP) ([]types.PortBinding, error) {
 	if ep.extConnConfig == nil || ep.extConnConfig.PortBindings == nil {
 		return nil, nil
 	}
@@ -86,99 +86,21 @@ func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, bindIntf string, reqDe
 		defHostIP = reqDefBindIP
 	}
 
-	bs, err := n.allocatePortsInternal(ep.extConnConfig.PortBindings, bindIntf, ep.addr.IP, defHostIP)
-	if err != nil {
-		return nil, err
+	bs := make([]types.PortBinding, 0, len(ep.extConnConfig.PortBindings))
+	for _, bnd := range ep.extConnConfig.PortBindings {
+		cp := bnd.GetCopy()
+		if len(cp.HostIP) == 0 {
+			cp.HostIP = defHostIP
+		}
+		if cp.HostPortEnd == 0 {
+			cp.HostPortEnd = cp.HostPort
+		}
+		cp.IP = ep.addr.IP
+		bs = append(bs, cp)
 	}
 
-	// Add PF rules for port bindings, if any
-	if len(bs) > 0 {
-		addPFRules(ep.id, bindIntf, bs)
-	}
-
+	err := n.portMapper.MapPorts(bs)
 	return bs, err
-}
-
-func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, bindIntf string, containerIP, defHostIP net.IP) ([]types.PortBinding, error) {
-	bs := make([]types.PortBinding, 0, len(bindings))
-	for _, c := range bindings {
-		b := c.GetCopy()
-		if err := n.allocatePort(&b, containerIP, defHostIP); err != nil {
-			// On allocation failure,release previously
-			// allocated ports. On cleanup error, just log
-			// a warning message
-			if cuErr := n.releasePortsInternal(bs); cuErr != nil {
-				logrus.Warnf("Upon allocation failure "+
-					"for %v, failed to clear previously "+
-					"allocated port bindings: %v", b, cuErr)
-			}
-			return nil, err
-		}
-		bs = append(bs, b)
-	}
-	return bs, nil
-}
-
-func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHostIP net.IP) error {
-	var (
-		host net.Addr
-		err  error
-	)
-
-	// Store the container interface address in the operational binding
-	bnd.IP = containerIP
-
-	// Adjust the host address in the operational binding
-	if len(bnd.HostIP) == 0 {
-		bnd.HostIP = defHostIP
-	}
-
-	// Adjust HostPortEnd if this is not a range.
-	if bnd.HostPortEnd == 0 {
-		bnd.HostPortEnd = bnd.HostPort
-	}
-
-	// Construct the container side transport address
-	container, err := bnd.ContainerAddr()
-	if err != nil {
-		return err
-	}
-
-	// Try up to maxAllocatePortAttempts times to get a port that's
-	// not already allocated.
-	for i := 0; i < maxAllocatePortAttempts; i++ {
-		if host, err = n.portMapper.MapRange(container, bnd.HostIP,
-			int(bnd.HostPort), int(bnd.HostPortEnd)); err == nil {
-			break
-		}
-		// There is no point in immediately retrying to map an
-		// explicitly chosen port.
-		if bnd.HostPort != 0 {
-			logrus.Warnf(
-				"Failed to allocate and map port %d-%d: %s",
-				bnd.HostPort, bnd.HostPortEnd, err)
-			break
-		}
-		logrus.Warnf("Failed to allocate and map port: %s, retry: %d",
-			err, i+1)
-	}
-	if err != nil {
-		return err
-	}
-
-	// Save the host port (regardless it was or not specified in the
-	// binding)
-	switch netAddr := host.(type) {
-	case *net.TCPAddr:
-		bnd.HostPort = uint16(host.(*net.TCPAddr).Port)
-		return nil
-	case *net.UDPAddr:
-		bnd.HostPort = uint16(host.(*net.UDPAddr).Port)
-		return nil
-	default:
-		// For completeness
-		return ErrUnsupportedAddressType(fmt.Sprintf("%T", netAddr))
-	}
 }
 
 func (n *bridgeNetwork) releasePorts(ep *bridgeEndpoint) error {

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -1,7 +1,6 @@
 package portmapper
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -9,7 +8,11 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/portallocator"
+	"github.com/docker/libnetwork/types"
+	"github.com/pkg/errors"
 )
+
+const maxAllocatePortAttempts = 10
 
 type mapping struct {
 	proto         string
@@ -27,6 +30,8 @@ var (
 	ErrPortMappedForIP = errors.New("port is already mapped to ip")
 	// ErrPortNotMapped refers to an unmapped port
 	ErrPortNotMapped = errors.New("port is not mapped")
+	// ErrProtocolNotSupported is used when a requested protocol is not supported
+	ErrProtocolNotSupported = errors.New("protocol not supported")
 )
 
 // PortMapper manages the network address translation
@@ -88,108 +93,120 @@ func (pm *PortMapper) SetIptablesChain(c *iptables.ChainInfo, bridgeName string)
 	pm.bridgeName = bridgeName
 }
 
-// Map maps the specified container transport address to the host's network address and transport port
-func (pm *PortMapper) Map(container net.Addr, hostIP net.IP, hostPort int) (host net.Addr, err error) {
-	return pm.MapRange(container, hostIP, hostPort, hostPort)
+// MapPorts creates port forwards for each of the passed in ports
+// TODO: This could be optimized by grouping ports for the same source/target IP's
+//   for 1 call out to iptables.
+func (pm *PortMapper) MapPorts(binds []types.PortBinding) error {
+	for i, bind := range binds {
+		_, err := pm.mapPort(&bind)
+		if err != nil {
+			return err
+		}
+		binds[i] = bind
+	}
+	return nil
 }
 
-// MapRange maps the specified container transport address to the host's network address and transport port range
-func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart, hostPortEnd int) (host net.Addr, err error) {
-	pm.lock.Lock()
-	defer pm.lock.Unlock()
-
-	var (
-		m                 *mapping
-		proto             string
-		allocatedHostPort int
-	)
-
-	switch container.(type) {
-	case *net.TCPAddr:
-		proto = "tcp"
-		if allocatedHostPort, err = pm.Allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
-			return nil, err
-		}
-
-		m = &mapping{
-			proto:     proto,
-			host:      &net.TCPAddr{IP: hostIP, Port: allocatedHostPort},
-			container: container,
-		}
-
-		if pm.enableUserlandProxy {
-			m.userlandProxy, err = newProxy(proto, hostIP, allocatedHostPort, container.(*net.TCPAddr).IP, container.(*net.TCPAddr).Port, pm.proxyPath)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			m.userlandProxy = newDummyProxy(proto, hostIP, allocatedHostPort)
-		}
-	case *net.UDPAddr:
-		proto = "udp"
-		if allocatedHostPort, err = pm.Allocator.RequestPortInRange(hostIP, proto, hostPortStart, hostPortEnd); err != nil {
-			return nil, err
-		}
-
-		m = &mapping{
-			proto:     proto,
-			host:      &net.UDPAddr{IP: hostIP, Port: allocatedHostPort},
-			container: container,
-		}
-
-		if pm.enableUserlandProxy {
-			m.userlandProxy, err = newProxy(proto, hostIP, allocatedHostPort, container.(*net.UDPAddr).IP, container.(*net.UDPAddr).Port, pm.proxyPath)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			m.userlandProxy = newDummyProxy(proto, hostIP, allocatedHostPort)
-		}
-	default:
-		return nil, ErrUnknownBackendAddressType
+func (pm *PortMapper) mapPort(bind *types.PortBinding) (frontend net.Addr, err error) {
+	if bind.HostPort > 0 && bind.HostPortEnd == 0 {
+		bind.HostPortEnd = bind.HostPort
 	}
-
-	// release the allocated port on any further error during return.
+	allocatedHostPort, err := tryAllocPort(pm.Allocator, bind.Proto.String(), bind.HostIP, int(bind.HostPort), int(bind.HostPortEnd))
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		if err != nil {
-			pm.Allocator.ReleasePort(hostIP, proto, allocatedHostPort)
+			pm.Allocator.ReleasePort(bind.HostIP, bind.Proto.String(), allocatedHostPort)
 		}
 	}()
 
-	key := getKey(m.host)
-	if _, exists := pm.currentMappings[key]; exists {
-		return nil, ErrPortMappedForIP
-	}
-
-	containerIP, containerPort := getIPAndPort(m.container)
-	if hostIP.To4() != nil {
-		if err := pm.forward(iptables.Append, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
-			return nil, err
-		}
-	}
-
-	cleanup := func() error {
-		// need to undo the iptables rules before we return
-		m.userlandProxy.Stop()
-		if hostIP.To4() != nil {
-			pm.forward(iptables.Delete, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
-			if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-
-	if err := m.userlandProxy.Start(); err != nil {
-		if err := cleanup(); err != nil {
-			return nil, fmt.Errorf("Error during port allocation cleanup: %v", err)
-		}
+	bind.HostPort = uint16(allocatedHostPort)
+	frontend, backend, err := portBindingToAddrs(bind)
+	if err != nil {
 		return nil, err
 	}
 
+	return frontend, pm.create(frontend, backend)
+}
+
+func portBindingToAddrs(bind *types.PortBinding) (frontend, backend net.Addr, err error) {
+	switch bind.Proto {
+	case types.TCP:
+		frontend = &net.TCPAddr{IP: bind.HostIP, Port: int(bind.HostPort)}
+		backend = &net.TCPAddr{IP: bind.IP, Port: int(bind.Port)}
+	case types.UDP:
+		frontend = &net.UDPAddr{IP: bind.HostIP, Port: int(bind.HostPort)}
+		backend = &net.UDPAddr{IP: bind.IP, Port: int(bind.Port)}
+	default:
+		err = ErrProtocolNotSupported
+	}
+	return
+}
+
+func (pm *PortMapper) create(frontend, backend net.Addr) (err error) {
+	m := &mapping{
+		proto:     frontend.Network(),
+		container: backend,
+		host:      frontend,
+	}
+
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+
+	key := getKey(m.host)
+	if _, exists := pm.currentMappings[key]; exists {
+		return ErrPortMappedForIP
+	}
+
+	frontendIP, frontendPort := getIPAndPort(frontend)
+	backendIP, backendPort := getIPAndPort(backend)
+
+	if pm.enableUserlandProxy {
+		m.userlandProxy, err = newProxy(m.proto, frontendIP, frontendPort, backendIP, backendPort, pm.proxyPath)
+	} else {
+		m.userlandProxy = newDummyProxy(m.proto, frontendIP, frontendPort)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if frontendIP.To4() != nil {
+		if err := pm.forward(iptables.Append, m.proto, frontendIP, frontendPort, backendIP, backendPort); err != nil {
+			return err
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			if frontendIP.To4() != nil {
+				pm.forward(iptables.Delete, m.proto, frontendIP, frontendPort, backendIP, backendPort)
+			}
+		}
+	}()
+
+	if err := m.userlandProxy.Start(); err != nil {
+		return err
+	}
+
 	pm.currentMappings[key] = m
-	return m.host, nil
+	return nil
+}
+
+func tryAllocPort(pa *portallocator.PortAllocator, proto string, ip net.IP, rangeStart, rangeEnd int) (allocPort int, err error) {
+	for i := 0; i < maxAllocatePortAttempts; i++ {
+		allocPort, err = pa.RequestPortInRange(ip, proto, rangeStart, rangeEnd)
+		if err == nil {
+			break
+		}
+
+		if rangeStart != 0 && rangeStart == rangeEnd {
+			// No point in trying to allocate a user-requested port over and over
+			return 0, errors.Errorf("failed to allocate and map port %d", rangeStart)
+		}
+	}
+	return
 }
 
 // Unmap removes stored mapping for the specified host transport address
@@ -211,7 +228,7 @@ func (pm *PortMapper) Unmap(host net.Addr) error {
 
 	containerIP, containerPort := getIPAndPort(data.container)
 	hostIP, hostPort := getIPAndPort(data.host)
-	if err := pm.forward(iptables.Delete, data.proto, hostIP, hostPort, containerIP.String(), containerPort); err != nil {
+	if err := pm.forward(iptables.Delete, data.proto, hostIP, hostPort, containerIP, containerPort); err != nil {
 		logrus.Errorf("Error on iptables delete: %s", err)
 	}
 
@@ -232,7 +249,7 @@ func (pm *PortMapper) ReMapAll() {
 	for _, data := range pm.currentMappings {
 		containerIP, containerPort := getIPAndPort(data.container)
 		hostIP, hostPort := getIPAndPort(data.host)
-		if err := pm.forward(iptables.Append, data.proto, hostIP, hostPort, containerIP.String(), containerPort); err != nil {
+		if err := pm.forward(iptables.Append, data.proto, hostIP, hostPort, containerIP, containerPort); err != nil {
 			logrus.Errorf("Error on iptables add: %s", err)
 		}
 	}
@@ -258,9 +275,9 @@ func getIPAndPort(a net.Addr) (net.IP, int) {
 	return nil, 0
 }
 
-func (pm *PortMapper) forward(action iptables.Action, proto string, sourceIP net.IP, sourcePort int, containerIP string, containerPort int) error {
+func (pm *PortMapper) forward(action iptables.Action, proto string, sourceIP net.IP, sourcePort int, containerIP net.IP, containerPort int) error {
 	if pm.chain == nil {
 		return nil
 	}
-	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort, pm.bridgeName)
+	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP.String(), containerPort, pm.bridgeName)
 }

--- a/portmapper/mapper_test.go
+++ b/portmapper/mapper_test.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func TestSetIptablesChain(t *testing.T) {
-	pm := New("")
+	pm := New()
 
 	c := &iptables.ChainInfo{
 		Name: "TEST",
@@ -32,7 +32,7 @@ func TestSetIptablesChain(t *testing.T) {
 }
 
 func TestMapTCPPorts(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP1 := net.ParseIP("192.168.0.1")
 	dstIP2 := net.ParseIP("192.168.0.2")
 	dstAddr1 := &net.TCPAddr{IP: dstIP1, Port: 80}
@@ -111,7 +111,7 @@ func TestGetUDPIPAndPort(t *testing.T) {
 }
 
 func TestMapUDPPorts(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP1 := net.ParseIP("192.168.0.1")
 	dstIP2 := net.ParseIP("192.168.0.2")
 	dstAddr1 := &net.UDPAddr{IP: dstIP1, Port: 80}
@@ -157,7 +157,7 @@ func TestMapUDPPorts(t *testing.T) {
 }
 
 func TestMapAllPortsSingleInterface(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP1 := net.ParseIP("0.0.0.0")
 	srcAddr1 := &net.TCPAddr{Port: 1080, IP: net.ParseIP("172.16.0.1")}
 
@@ -196,7 +196,7 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 }
 
 func TestMapTCPDummyListen(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP := net.ParseIP("0.0.0.0")
 	dstAddr := &net.TCPAddr{IP: dstIP, Port: 80}
 
@@ -233,7 +233,7 @@ func TestMapTCPDummyListen(t *testing.T) {
 }
 
 func TestMapUDPDummyListen(t *testing.T) {
-	pm := New("")
+	pm := New()
 	dstIP := net.ParseIP("0.0.0.0")
 	dstAddr := &net.UDPAddr{IP: dstIP, Port: 80}
 

--- a/portmapper/mapper_test.go
+++ b/portmapper/mapper_test.go
@@ -32,7 +32,7 @@ func TestSetIptablesChain(t *testing.T) {
 }
 
 func TestMapTCPPorts(t *testing.T) {
-	pm := New()
+	pm := New(WithUserlandProxy(true, ""))
 	dstIP1 := net.ParseIP("192.168.0.1")
 	dstIP2 := net.ParseIP("192.168.0.2")
 	dstAddr1 := &net.TCPAddr{IP: dstIP1, Port: 80}
@@ -45,22 +45,22 @@ func TestMapTCPPorts(t *testing.T) {
 		return (addr1.Network() == addr2.Network()) && (addr1.String() == addr2.String())
 	}
 
-	if host, err := pm.Map(srcAddr1, dstIP1, 80, true); err != nil {
+	if host, err := pm.Map(srcAddr1, dstIP1, 80); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	} else if !addrEqual(dstAddr1, host) {
 		t.Fatalf("Incorrect mapping result: expected %s:%s, got %s:%s",
 			dstAddr1.String(), dstAddr1.Network(), host.String(), host.Network())
 	}
 
-	if _, err := pm.Map(srcAddr1, dstIP1, 80, true); err == nil {
+	if _, err := pm.Map(srcAddr1, dstIP1, 80); err == nil {
 		t.Fatalf("Port is in use - mapping should have failed")
 	}
 
-	if _, err := pm.Map(srcAddr2, dstIP1, 80, true); err == nil {
+	if _, err := pm.Map(srcAddr2, dstIP1, 80); err == nil {
 		t.Fatalf("Port is in use - mapping should have failed")
 	}
 
-	if _, err := pm.Map(srcAddr2, dstIP2, 80, true); err != nil {
+	if _, err := pm.Map(srcAddr2, dstIP2, 80); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	}
 
@@ -111,7 +111,7 @@ func TestGetUDPIPAndPort(t *testing.T) {
 }
 
 func TestMapUDPPorts(t *testing.T) {
-	pm := New()
+	pm := New(WithUserlandProxy(true, ""))
 	dstIP1 := net.ParseIP("192.168.0.1")
 	dstIP2 := net.ParseIP("192.168.0.2")
 	dstAddr1 := &net.UDPAddr{IP: dstIP1, Port: 80}
@@ -124,22 +124,22 @@ func TestMapUDPPorts(t *testing.T) {
 		return (addr1.Network() == addr2.Network()) && (addr1.String() == addr2.String())
 	}
 
-	if host, err := pm.Map(srcAddr1, dstIP1, 80, true); err != nil {
+	if host, err := pm.Map(srcAddr1, dstIP1, 80); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	} else if !addrEqual(dstAddr1, host) {
 		t.Fatalf("Incorrect mapping result: expected %s:%s, got %s:%s",
 			dstAddr1.String(), dstAddr1.Network(), host.String(), host.Network())
 	}
 
-	if _, err := pm.Map(srcAddr1, dstIP1, 80, true); err == nil {
+	if _, err := pm.Map(srcAddr1, dstIP1, 80); err == nil {
 		t.Fatalf("Port is in use - mapping should have failed")
 	}
 
-	if _, err := pm.Map(srcAddr2, dstIP1, 80, true); err == nil {
+	if _, err := pm.Map(srcAddr2, dstIP1, 80); err == nil {
 		t.Fatalf("Port is in use - mapping should have failed")
 	}
 
-	if _, err := pm.Map(srcAddr2, dstIP2, 80, true); err != nil {
+	if _, err := pm.Map(srcAddr2, dstIP2, 80); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	}
 
@@ -174,14 +174,14 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		start, end := pm.Allocator.Begin, pm.Allocator.End
 		for i := start; i < end; i++ {
-			if host, err = pm.Map(srcAddr1, dstIP1, 0, true); err != nil {
+			if host, err = pm.Map(srcAddr1, dstIP1, 0); err != nil {
 				t.Fatal(err)
 			}
 
 			hosts = append(hosts, host)
 		}
 
-		if _, err := pm.Map(srcAddr1, dstIP1, start, true); err == nil {
+		if _, err := pm.Map(srcAddr1, dstIP1, start); err == nil {
 			t.Fatalf("Port %d should be bound but is not", start)
 		}
 
@@ -207,7 +207,7 @@ func TestMapTCPDummyListen(t *testing.T) {
 		return (addr1.Network() == addr2.Network()) && (addr1.String() == addr2.String())
 	}
 
-	if host, err := pm.Map(srcAddr, dstIP, 80, false); err != nil {
+	if host, err := pm.Map(srcAddr, dstIP, 80); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	} else if !addrEqual(dstAddr, host) {
 		t.Fatalf("Incorrect mapping result: expected %s:%s, got %s:%s",
@@ -223,7 +223,7 @@ func TestMapTCPDummyListen(t *testing.T) {
 	if _, err := net.Listen("tcp", "0.0.0.0:81"); err != nil {
 		t.Fatal(err)
 	}
-	if host, err := pm.Map(srcAddr, dstIP, 81, false); err == nil {
+	if host, err := pm.Map(srcAddr, dstIP, 81); err == nil {
 		t.Fatalf("Bound port shouldn't be allocated, but it was on: %v", host)
 	} else {
 		if !strings.Contains(err.Error(), "address already in use") {
@@ -244,7 +244,7 @@ func TestMapUDPDummyListen(t *testing.T) {
 		return (addr1.Network() == addr2.Network()) && (addr1.String() == addr2.String())
 	}
 
-	if host, err := pm.Map(srcAddr, dstIP, 80, false); err != nil {
+	if host, err := pm.Map(srcAddr, dstIP, 80); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	} else if !addrEqual(dstAddr, host) {
 		t.Fatalf("Incorrect mapping result: expected %s:%s, got %s:%s",
@@ -260,7 +260,7 @@ func TestMapUDPDummyListen(t *testing.T) {
 	if _, err := net.ListenUDP("udp", &net.UDPAddr{IP: dstIP, Port: 81}); err != nil {
 		t.Fatal(err)
 	}
-	if host, err := pm.Map(srcAddr, dstIP, 81, false); err == nil {
+	if host, err := pm.Map(srcAddr, dstIP, 81); err == nil {
 		t.Fatalf("Bound port shouldn't be allocated, but it was on: %v", host)
 	} else {
 		if !strings.Contains(err.Error(), "address already in use") {


### PR DESCRIPTION
- Cleans up portmapper initizliation to use functional arguments
- Pass `userlandProxyEnabled` setting on portmapper init instead of for each request to map a port
- Pass a list of port bindings to the portmapper instead of itterating through each one
- Just general cleanup to what was `MapRange()`, now no longer exported and called `create()`