### PR TITLE
portallocator: immediately reuse released ports

### DIFF
--- a/portallocator/portallocator.go
+++ b/portallocator/portallocator.go
@@ -165,6 +165,14 @@ func (p *PortAllocator) ReleasePort(ip net.IP, proto string, port int) error {
 	if !ok {
 		return nil
 	}
+	for _, pr := range protomap[proto].portRanges {
+		if port >= pr.begin && port <= pr.last {
+			pr.last = port - 1
+			if pr.last < pr.begin {
+				pr.last = pr.end
+			}
+		}
+	}
 	delete(protomap[proto].p, port)
 	return nil
 }

--- a/portallocator/portallocator_test.go
+++ b/portallocator/portallocator_test.go
@@ -318,3 +318,30 @@ func TestNoDuplicateBPR(t *testing.T) {
 		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)
 	}
 }
+
+func TestReusePortAllocation(t *testing.T) {
+	p := Get()
+	defer resetPortAllocator()
+
+	port1, err := p.RequestPortInRange(defaultIP, "tcp", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := p.RequestPortInRange(defaultIP, "tcp", 0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.ReleasePort(defaultIP, "tcp", port1); err != nil {
+		t.Fatal(err)
+	}
+
+	port2, err := p.RequestPortInRange(defaultIP, "tcp", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if port2 != port1 {
+		t.Fatalf("Failed to reuse released port. Expected port: %d, got %d", port1, port2)
+	}
+}


### PR DESCRIPTION
This patch help a container reuse the same port after it restarts.
It doesn't guarantee the same port will be allocated though. For
example, 3 containers restarts at the same time.

An alternative approach is to update portRange.last to the smallest
port that is available in portallocator.ReleasePort. But it will
make the allocation more complex.

Relates to docker/docker#31926

Signed-off-by: Jacob Wen <jian.w.wen@oracle.com>