### PR TITLE
bug fix for epCnt cocurrent race problem, which make epCnt in remote store not right, and there is no need to compare epCnt and len(epl)

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1170,17 +1170,5 @@ func (c *controller) cleanupLocalEndpoints() {
 				logrus.Warnf("Could not delete local endpoint %s during endpoint cleanup: %v", ep.name, err)
 			}
 		}
-
-		epl, err = n.getEndpointsFromStore()
-		if err != nil {
-			logrus.Warnf("Could not get list of endpoints in network %s for count update: %v", n.name, err)
-			continue
-		}
-
-		epCnt := n.getEpCnt().EndpointCnt()
-		if epCnt != uint64(len(epl)) {
-			logrus.Infof("Fixing inconsistent endpoint_cnt for network %s. Expected=%d, Actual=%d", n.name, len(epl), epCnt)
-			n.getEpCnt().setCnt(uint64(len(epl)))
-		}
 	}
 }


### PR DESCRIPTION
when dockerd was restart, the method `cleanupLocalEndpoints()` would be called, and this method will call method `n.getEpCnt().setCnt(uint64(len(epl)))`, however, `setCnt` will force update the endpoint_count value in the remote store, and this may cause endpoint_count not right if cocurrently some dockerd on the different host is starting or stopping containers, and the wrong endpoint_count of some globel network will finally make this network cannot be deleted, because before deleting network, dockerd will check whether the value of endpoint_count is {"Count": 0}, however, if this value is wrong because the criteria mentioned above, the network will not be allowed to delete, and we have to manually change the value to be {"Count": 0}, then, the network can be deteted.

this bug has followed docker form 1.9.0 up to now, I hope it can be fixed. thx~

fix [https://github.com/moby/moby/issues/19261](https://github.com/moby/moby/issues/19261)
Signed-off-by: Xin He <he_xinworld@126.com>