### PR TITLE
dnet: fix returned value of GetRemoteAddressList

### DIFF
--- a/cmd/dnet/dnet.go
+++ b/cmd/dnet/dnet.go
@@ -326,7 +326,7 @@ func (d *dnetConnection) GetListenAddress() string {
 }
 
 func (d *dnetConnection) GetRemoteAddressList() []string {
-	return []string{d.Orchestration.Peer}
+	return strings.Split(d.Orchestration.Peer, ",")
 }
 
 func (d *dnetConnection) GetNetworkKeys() []*types.EncryptionKey {

--- a/test/integration/dnet/helpers.bash
+++ b/test/integration/dnet/helpers.bash
@@ -184,6 +184,7 @@ title = "LibNetwork Configuration file for ${name}"
       provider = "${provider}"
       address = "${address}"
 EOF
+    echo "Use external KV"
     else
 	cat > ${tomlfile} <<EOF
 title = "LibNetwork Configuration file for ${name}"
@@ -195,6 +196,8 @@ title = "LibNetwork Configuration file for ${name}"
   bind = "eth0"
   peer = "${neighbors}"
 EOF
+    echo "In agent mode"
+    cat ${tomlfile}
     fi
 
     cat ${tomlfile}

--- a/test/integration/dnet/run-integration-tests.sh
+++ b/test/integration/dnet/run-integration-tests.sh
@@ -45,7 +45,7 @@ function run_overlay_local_tests() {
     cmap[dnet-3-local]=dnet-3-local
 
     ## Run the test cases
-    ./integration-tmp/bin/bats ./test/integration/dnet/overlay-local.bats
+    ./integration-tmp/bin/bats --tap ./test/integration/dnet/overlay-local.bats
 
     ## Teardown
     stop_dnet 1 local 1>>${INTEGRATION_ROOT}/test.log 2>&1
@@ -67,7 +67,7 @@ function run_overlay_consul_tests() {
     cmap[dnet-3-consul]=dnet-3-consul
 
     ## Run the test cases
-    ./integration-tmp/bin/bats ./test/integration/dnet/overlay-consul.bats
+    ./integration-tmp/bin/bats --tap ./test/integration/dnet/overlay-consul.bats
 
     ## Teardown
     stop_dnet 1 consul 1>>${INTEGRATION_ROOT}/test.log 2>&1
@@ -162,7 +162,7 @@ function run_multi_consul_tests() {
     cmap[dnet-3-multi_consul]=dnet-3-multi_consul
 
     ## Run the test cases
-    ./integration-tmp/bin/bats ./test/integration/dnet/multi.bats
+    ./integration-tmp/bin/bats --tap ./test/integration/dnet/multi.bats
 
     ## Teardown
     stop_dnet 1 multi_consul 1>>${INTEGRATION_ROOT}/test.log 2>&1
@@ -208,7 +208,7 @@ function run_multi_etcd_tests() {
     cmap[dnet-3-multi_etcd]=dnet-3-multi_etcd
 
     ## Run the test cases
-    ./integration-tmp/bin/bats ./test/integration/dnet/multi.bats
+    ./integration-tmp/bin/bats --tap ./test/integration/dnet/multi.bats
 
     ## Teardown
     stop_dnet 1 multi_etcd 1>>${INTEGRATION_ROOT}/test.log 2>&1


### PR DESCRIPTION
- should return a string slice of peers

Signed-off-by: Hui Kang <kangh@us.ibm.com>