### PR TITLE
Fix race in overlay driver node join

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -260,6 +260,10 @@ func validateSelf(node string) error {
 	return fmt.Errorf("Multi-Host overlay networking requires cluster-advertise(%s) to be configured with a local ip-address that is reachable within the cluster", advIP.String())
 }
 
+// Goroutine to join this node to a discovered Serf neighbour. This will listen
+// for items pushed into `joinQueue`, and attempt to call `serfJoin on them`.
+// When a join is successful, all items are removed from `joinQueue` and this
+// goroutine exits.
 func (d *driver) nodeJoinWorker() {
 	// Lock the object, and attempt to join everything in
 	for !d.joinDone {

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -50,7 +50,6 @@ type driver struct {
 	localStore       datastore.DataStore
 	vxlanIdm         *idm.Idm
 	initOS           sync.Once
-	joinOnce         sync.Once
 	localJoinOnce    sync.Once
 	keys             []*key
 	peerOpCh         chan *peerOperation


### PR DESCRIPTION
This code fixes a race within `nodeJoin` which could prevent a new Docker engine using overlay networking from being able to join the serf pool. This in turn prevents the node from being able to communicate with existing Docker engines using overlay networking. This was discovered when attempting to ascertain the root cause of #1849, but there isn't currently a bug open for this specific issue.

In short, `nodeJoin` is called for every node which appears in Docker's global K/V store. When a node X joins the cluster, `nodeJoin` will be called for every other peer quickly on node X, allowing it to join the Serf pool.

Due to this method racing `joinOnce`, if the first node `nodeJoin` is called for has failed, the node typically cannot join the cluster. This is because the initial call to `joinOnce` attempts to join to the failed node, blocking all other invocations of `nodeJoin` from calling `serfJoin` to potentially healthy nodes. With sufficient network latency, `nodeJoin` will have been called for all nodes currently in the K/V store _before_ `joinOnce` can be "reset" after failure.

[This file](https://github.com/docker/libnetwork/files/1259765/joinleavefail.txt) is a shell script which effectively demonstrates this error in some situations. It can also be reproduced using three nodes and the following procedure:

* Start a Docker instance using overlay networking.
* Start a long-running container on the first node (say, nginx or similar) on a new overlay network.
* Start another Docker instance. Start a simple Debian container on this instance, on the overlay network from the previous step. Verify that this container can communicate with nginx.
* Forcefully kill the second Docker instance (running Debian). Wait 5 seconds. 
* Start a new Docker instance
* Start a container on this new Docker instance. Verify that the new container cannot communicate with the old nginx container.

This PR instead spawns a "listener" goroutine, which listens on a queue and attempts to join on nodes pushed into this queue. If the join fails, it will try the next one, otherwise, will blank the queue and exit.

There are alternative implementations of this which were discounted for a few reasons. One option was to simply throw a lock around the whole subroutine which joins Serf (i.e. remove the Once and instead put a lock around it). This isn't totally suitable, as we need to find the "self" node before Serf can be started. Doing this could cause the nodes discovered before the "self" node to be missed.

Another implementation could use channels to buffer the peers, rather than using an explicit queue (and managing the locking manually). This isn't suitable as, with a channel of fixed size, nodes may be missed using non-blocking sending. Go's semantics also effectively prevent a message receiver from closing the channel.

Signed-off-by: Jamie Garside <jgarside@uk.ibm.com>