### PR TITLE
Fix moby/moby/#32675 by responding when external name servers don't

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -500,6 +500,12 @@ func (r *resolver) ServeDNS(w dns.ResponseWriter, query *dns.Msg) {
 			break
 		}
 		if resp == nil {
+			logrus.Debugf("[resolver] failed to resolve through external DNS servers")
+			resp = new(dns.Msg)
+			resp.SetRcode(query, dns.RcodeServerFailure)
+			if err = w.WriteMsg(resp); err != nil {
+				logrus.Errorf("[resolver] failed to write error response: %s", err)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Issue https://github.com/moby/moby/issues/32675 is caused by the embedded resolver not responding when the external name server fails to respond or there are no external ipv4 name servers configured. This happens when the host only has an ipv6 network. By responding appropriately the containers resolver is able to move onto the next name server in its resolv.conf immediately without having to wait for the timeout.