### PR TITLE
Add comments to the resolv.conf file.

### DIFF
--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -223,8 +223,21 @@ func GetOptions(resolvConf []byte) []string {
 // Build writes a configuration file to path containing a "nameserver" entry
 // for every element in dns, a "search" entry for every element in
 // dnsSearch, and an "options" entry for every element in dnsOptions.
-func Build(path string, dns, dnsSearch, dnsOptions []string) (*File, error) {
+func Build(path string, dns, dnsSearch, dnsOptions []string, comments string) (*File, error) {
 	content := bytes.NewBuffer(nil)
+	if len(comments) > 0 {
+		commentLine := strings.Split(comments, "\n")
+		for i := range commentLine {	
+			if _, err := content.WriteString("# " + commentLine[i] + "\n"); err != nil {
+				return nil, err
+			}
+		}
+	}
+	else {
+		if _, err := content.WriteString("# This file was created by Docker" + dns + "\n"); err != nil {
+			return nil, err
+		}
+	}
 	if len(dnsSearch) > 0 {
 		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
 			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {

--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -232,8 +232,7 @@ func Build(path string, dns, dnsSearch, dnsOptions []string, comments string) (*
 				return nil, err
 			}
 		}
-	}
-	else {
+	} else {
 		if _, err := content.WriteString("# This file was created by Docker" + dns + "\n"); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
It can be confusing when you use the --dns x.x.x.x option on a container, to find it has not been added to resolv.conf

This is true for example, when you use the Macvlan network driver.  --dns is added to the Docker DNS server, and not resolv.conf.

I would suggest we see something like:

```
# --dns x.x.x.x has been added to Dockers internal DNS server
namserver 127.0.0.11
options ndots:0
```

or where no override setting made.

```
# File set by Docker for the internal DNS server
namserver 127.0.0.11
options ndots:0
```