### PR TITLE
Enable IPv6 NAT (Cleaner commits)

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -50,6 +50,7 @@ type configuration struct {
 	EnableIPForwarding  bool
 	EnableIPTables      bool
 	EnableUserlandProxy bool
+	EnableIPv6          bool
 	UserlandProxyPath   string
 }
 
@@ -123,20 +124,24 @@ type bridgeNetwork struct {
 	config        *networkConfiguration
 	endpoints     map[string]*bridgeEndpoint // key: endpoint id
 	portMapper    *portmapper.PortMapper
+	portMapperV6  *portmapper.PortMapper
 	driver        *driver // The network's driver
 	iptCleanFuncs iptablesCleanFuncs
 	sync.Mutex
 }
 
 type driver struct {
-	config         *configuration
-	network        *bridgeNetwork
-	natChain       *iptables.ChainInfo
-	filterChain    *iptables.ChainInfo
-	isolationChain *iptables.ChainInfo
-	networks       map[string]*bridgeNetwork
-	store          datastore.DataStore
-	nlh            *netlink.Handle
+	config           *configuration
+	network          *bridgeNetwork
+	natChain         *iptables.ChainInfo
+	filterChain      *iptables.ChainInfo
+	isolationChain   *iptables.ChainInfo
+	natChainV6       *iptables.ChainInfo
+	filterChainV6    *iptables.ChainInfo
+	isolationChainV6 *iptables.ChainInfo
+	networks         map[string]*bridgeNetwork
+	store            datastore.DataStore
+	nlh              *netlink.Handle
 	sync.Mutex
 }
 
@@ -257,12 +262,16 @@ func (n *bridgeNetwork) registerIptCleanFunc(clean iptableCleanFunc) {
 	n.iptCleanFuncs = append(n.iptCleanFuncs, clean)
 }
 
-func (n *bridgeNetwork) getDriverChains() (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
+func (n *bridgeNetwork) getDriverChains(version iptables.IPVersion) (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
 	n.Lock()
 	defer n.Unlock()
 
 	if n.driver == nil {
 		return nil, nil, nil, types.BadRequestErrorf("no driver found")
+	}
+
+	if version == iptables.IPv6 {
+		return n.driver.natChainV6, n.driver.filterChainV6, n.driver.isolationChainV6, nil
 	}
 
 	return n.driver.natChain, n.driver.filterChain, n.driver.isolationChain, nil
@@ -293,7 +302,7 @@ func (n *bridgeNetwork) getEndpoint(eid string) (*bridgeEndpoint, error) {
 
 // Install/Removes the iptables rules needed to isolate this network
 // from each of the other networks
-func (n *bridgeNetwork) isolateNetwork(others []*bridgeNetwork, enable bool) error {
+func (n *bridgeNetwork) isolateNetwork(version iptables.IPVersion, others []*bridgeNetwork, enable bool) error {
 	n.Lock()
 	thisConfig := n.config
 	n.Unlock()
@@ -313,7 +322,7 @@ func (n *bridgeNetwork) isolateNetwork(others []*bridgeNetwork, enable bool) err
 		}
 
 		if thisConfig.BridgeName != otherConfig.BridgeName {
-			if err := setINC(thisConfig.BridgeName, otherConfig.BridgeName, enable); err != nil {
+			if err := setINC(version, thisConfig.BridgeName, otherConfig.BridgeName, enable); err != nil {
 				return err
 			}
 		}
@@ -352,6 +361,13 @@ func (c *networkConfiguration) conflictsWithNetworks(id string, others []*bridge
 				return types.ForbiddenErrorf("conflicts with network %s (%s) by ip network", nwID, nwConfig.BridgeName)
 			}
 		}
+		// Same for IPv6
+		if c.AddressIPv6 != nil && nwBridge.bridgeIPv6 != nil {
+			if nwBridge.bridgeIPv6.Contains(c.AddressIPv6.IP) ||
+				c.AddressIPv6.Contains(nwBridge.bridgeIPv6.IP) {
+				return types.ForbiddenErrorf("IPv6 conflicts with network %s (%s) by ip network", nwID, nwConfig.BridgeName)
+			}
+		}
 	}
 
 	return nil
@@ -359,11 +375,14 @@ func (c *networkConfiguration) conflictsWithNetworks(id string, others []*bridge
 
 func (d *driver) configure(option map[string]interface{}) error {
 	var (
-		config         *configuration
-		err            error
-		natChain       *iptables.ChainInfo
-		filterChain    *iptables.ChainInfo
-		isolationChain *iptables.ChainInfo
+		config           *configuration
+		err              error
+		natChain         *iptables.ChainInfo
+		filterChain      *iptables.ChainInfo
+		isolationChain   *iptables.ChainInfo
+		natChainV6       *iptables.ChainInfo
+		filterChainV6    *iptables.ChainInfo
+		isolationChainV6 *iptables.ChainInfo
 	)
 
 	genericData, ok := option[netlabel.GenericData]
@@ -390,13 +409,32 @@ func (d *driver) configure(option map[string]interface{}) error {
 				logrus.Warnf("Running modprobe bridge br_netfilter failed with message: %s, error: %v", out, err)
 			}
 		}
-		removeIPChains()
-		natChain, filterChain, isolationChain, err = setupIPChains(config)
+
+		removeIPChains(iptables.IPv4)
+		if config.EnableIPv6 {
+			removeIPChains(iptables.IPv6)
+		}
+
+		natChain, filterChain, isolationChain, err = setupIPChains(config, iptables.IPv4)
 		if err != nil {
 			return err
 		}
+		if config.EnableIPv6 {
+			natChainV6, filterChainV6, isolationChainV6, err = setupIPChains(config, iptables.IPv6)
+			if err != nil {
+				return err
+			}
+		}
+
 		// Make sure on firewall reload, first thing being re-played is chains creation
-		iptables.OnReloaded(func() { logrus.Debugf("Recreating iptables chains on firewall reload"); setupIPChains(config) })
+		iptables.OnReloaded(func() {
+			logrus.Debugf("Recreating iptables chains on firewall reload")
+			setupIPChains(config, iptables.IPv4)
+		})
+		iptables.OnReloaded(func() {
+			logrus.Debugf("Recreating ip6tables chains on firewall reload")
+			setupIPChains(config, iptables.IPv6)
+		})
 	}
 
 	if config.EnableIPForwarding {
@@ -405,12 +443,21 @@ func (d *driver) configure(option map[string]interface{}) error {
 			logrus.Warn(err)
 			return err
 		}
+		if config.EnableIPv6 {
+			iptable := iptables.GetIptable(iptables.IPv6)
+			if err := iptable.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+				logrus.Warnf("Settig the default DROP policy on firewall reload failed, %v", err)
+			}
+		}
 	}
 
 	d.Lock()
 	d.natChain = natChain
 	d.filterChain = filterChain
 	d.isolationChain = isolationChain
+	d.natChainV6 = natChainV6
+	d.filterChainV6 = filterChainV6
+	d.isolationChainV6 = isolationChainV6
 	d.config = config
 	d.Unlock()
 
@@ -645,11 +692,12 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 
 	// Create and set network handler in driver
 	network := &bridgeNetwork{
-		id:         config.ID,
-		endpoints:  make(map[string]*bridgeEndpoint),
-		config:     config,
-		portMapper: portmapper.New(d.config.UserlandProxyPath),
-		driver:     d,
+		id:           config.ID,
+		endpoints:    make(map[string]*bridgeEndpoint),
+		config:       config,
+		portMapper:   portmapper.New(d.config.UserlandProxyPath),
+		portMapperV6: portmapper.New(d.config.UserlandProxyPath),
+		driver:       d,
 	}
 
 	d.Lock()
@@ -686,17 +734,16 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 	if err = config.conflictsWithNetworks(config.ID, networkList); err != nil {
 		return err
 	}
-
 	setupNetworkIsolationRules := func(config *networkConfiguration, i *bridgeInterface) error {
-		if err := network.isolateNetwork(networkList, true); err != nil {
-			if err := network.isolateNetwork(networkList, false); err != nil {
+		if err := network.isolateNetwork(iptables.IPv4, networkList, true); err != nil {
+			if err := network.isolateNetwork(iptables.IPv4, networkList, false); err != nil {
 				logrus.Warnf("Failed on removing the inter-network iptables rules on cleanup: %v", err)
 			}
 			return err
 		}
 		network.registerIptCleanFunc(func() error {
 			nwList := d.getNetworks()
-			return network.isolateNetwork(nwList, false)
+			return network.isolateNetwork(iptables.IPv4, nwList, false)
 		})
 		return nil
 	}

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -465,7 +465,8 @@ func TestCreateMultipleNetworks(t *testing.T) {
 }
 
 func verifyV4INCEntries(networks map[string]*bridgeNetwork, numEntries int, t *testing.T) {
-	out, err := iptables.Raw("-nvL", IsolationChain)
+	iptable := iptables.GetIptable(iptables.IPv4)
+	out, err := iptable.Raw("-nvL", IsolationChain)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -714,6 +715,7 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	d := newDriver()
+	iptable := iptables.GetIptable(iptables.IPv4)
 
 	config := &configuration{
 		EnableIPTables: true,
@@ -789,7 +791,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
 
-	out, err := iptables.Raw("-L", DockerChain)
+	out, err := iptable.Raw("-L", DockerChain)
 	for _, pm := range exposedPorts {
 		regex := fmt.Sprintf("%s dpt:%d", pm.Proto.String(), pm.Port)
 		re := regexp.MustCompile(regex)
@@ -815,7 +817,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatal("Failed to unlink ep1 and ep2")
 	}
 
-	out, err = iptables.Raw("-L", DockerChain)
+	out, err = iptable.Raw("-L", DockerChain)
 	for _, pm := range exposedPorts {
 		regex := fmt.Sprintf("%s dpt:%d", pm.Proto.String(), pm.Port)
 		re := regexp.MustCompile(regex)
@@ -843,7 +845,7 @@ func TestLinkContainers(t *testing.T) {
 	}
 	err = d.ProgramExternalConnectivity("net1", "ep2", sbOptions)
 	if err != nil {
-		out, err = iptables.Raw("-L", DockerChain)
+		out, err = iptable.Raw("-L", DockerChain)
 		for _, pm := range exposedPorts {
 			regex := fmt.Sprintf("%s dpt:%d", pm.Proto.String(), pm.Port)
 			re := regexp.MustCompile(regex)
@@ -997,18 +999,25 @@ func TestCleanupIptableRules(t *testing.T) {
 		{Name: DockerChain, Table: iptables.Filter},
 		{Name: IsolationChain, Table: iptables.Filter},
 	}
-	if _, _, _, err := setupIPChains(&configuration{EnableIPTables: true}); err != nil {
-		t.Fatalf("Error setting up ip chains: %v", err)
-	}
-	for _, chainInfo := range bridgeChain {
-		if !iptables.ExistChain(chainInfo.Name, chainInfo.Table) {
-			t.Fatalf("iptables chain %s of %s table should have been created", chainInfo.Name, chainInfo.Table)
+
+	ipVersions := []iptables.IPVersion{iptables.IPv4, iptables.IPv6}
+
+	for _, version := range ipVersions {
+		if _, _, _, err := setupIPChains(&configuration{EnableIPTables: true}, version); err != nil {
+			t.Fatalf("Error setting up ip chains for %s: %v", version, err)
 		}
-	}
-	removeIPChains()
-	for _, chainInfo := range bridgeChain {
-		if iptables.ExistChain(chainInfo.Name, chainInfo.Table) {
-			t.Fatalf("iptables chain %s of %s table should have been deleted", chainInfo.Name, chainInfo.Table)
+
+		iptable := iptables.GetIptable(version)
+		for _, chainInfo := range bridgeChain {
+			if !iptable.ExistChain(chainInfo.Name, chainInfo.Table) {
+				t.Fatalf("iptables version %s chain %s of %s table should have been created", version, chainInfo.Name, chainInfo.Table)
+			}
+		}
+		removeIPChains(version)
+		for _, chainInfo := range bridgeChain {
+			if iptable.ExistChain(chainInfo.Name, chainInfo.Table) {
+				t.Fatalf("iptables version %s chain %s of %s table should have been deleted", version, chainInfo.Name, chainInfo.Table)
+			}
 		}
 	}
 }

--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	defaultBindingIP   = net.IPv4(0, 0, 0, 0)
-	defaultBindingIPV6 = net.ParseIP("::")
+	defaultBindingIPV6 = net.ParseIP("::1")
 )
 
 func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {

--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -5,13 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/docker/libnetwork/types"
 	"github.com/sirupsen/logrus"
 )
 
 var (
-	defaultBindingIP = net.IPv4(0, 0, 0, 0)
+	defaultBindingIP   = net.IPv4(0, 0, 0, 0)
+	defaultBindingIPV6 = net.ParseIP("::")
 )
 
 func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
@@ -24,11 +26,23 @@ func (n *bridgeNetwork) allocatePorts(ep *bridgeEndpoint, reqDefBindIP net.IP, u
 		defHostIP = reqDefBindIP
 	}
 
-	return n.allocatePortsInternal(ep.extConnConfig.PortBindings, ep.addr.IP, defHostIP, ulPxyEnabled)
+	var pb []types.PortBinding
+
+	if ep.addrv6 != nil {
+		pb, _ = n.allocatePortsInternal(ep.extConnConfig.PortBindings, ep.addrv6.IP, defaultBindingIPV6, ulPxyEnabled, nil)
+	}
+
+	return n.allocatePortsInternal(ep.extConnConfig.PortBindings, ep.addr.IP, defHostIP, ulPxyEnabled, pb)
 }
 
-func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, containerIP, defHostIP net.IP, ulPxyEnabled bool) ([]types.PortBinding, error) {
-	bs := make([]types.PortBinding, 0, len(bindings))
+func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, containerIP, defHostIP net.IP, ulPxyEnabled bool, existingPortBindings []types.PortBinding) ([]types.PortBinding, error) {
+
+	bs := existingPortBindings
+
+	if existingPortBindings == nil {
+		bs = make([]types.PortBinding, 0, len(bindings))
+	}
+
 	for _, c := range bindings {
 		b := c.GetCopy()
 		if err := n.allocatePort(&b, containerIP, defHostIP, ulPxyEnabled); err != nil {
@@ -68,9 +82,15 @@ func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, containerIP, defHos
 		return err
 	}
 
+	portmapper := n.portMapper
+
+	if containerIP.To4() == nil {
+		portmapper = n.portMapperV6
+	}
+
 	// Try up to maxAllocatePortAttempts times to get a port that's not already allocated.
 	for i := 0; i < maxAllocatePortAttempts; i++ {
-		if host, err = n.portMapper.MapRange(container, bnd.HostIP, int(bnd.HostPort), int(bnd.HostPortEnd), ulPxyEnabled); err == nil {
+		if host, err = portmapper.MapRange(container, bnd.HostIP, int(bnd.HostPort), int(bnd.HostPortEnd), ulPxyEnabled); err == nil {
 			break
 		}
 		// There is no point in immediately retrying to map an explicitly chosen port.
@@ -124,5 +144,12 @@ func (n *bridgeNetwork) releasePort(bnd types.PortBinding) error {
 	if err != nil {
 		return err
 	}
-	return n.portMapper.Unmap(host)
+
+	portmapper := n.portMapper
+
+	if strings.ContainsAny(host.String(), "]") == true {
+		portmapper = n.portMapperV6
+	}
+
+	return portmapper.Unmap(host)
 }

--- a/drivers/bridge/setup_firewalld.go
+++ b/drivers/bridge/setup_firewalld.go
@@ -16,5 +16,9 @@ func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeIn
 	iptables.OnReloaded(func() { n.setupIPTables(config, i) })
 	iptables.OnReloaded(n.portMapper.ReMapAll)
 
+	if driverConfig.EnableIPv6 == true {
+		iptables.OnReloaded(n.portMapperV6.ReMapAll)
+	}
+
 	return nil
 }

--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -39,7 +39,8 @@ func setupIPForwarding(enableIPTables bool) error {
 		if !enableIPTables {
 			return nil
 		}
-		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+		iptable := iptables.GetIptable(iptables.IPv4)
+		if err := iptable.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 			if err := configureIPForwarding(false); err != nil {
 				logrus.Errorf("Disabling IP forwarding failed, %v", err)
 			}
@@ -47,7 +48,7 @@ func setupIPForwarding(enableIPTables bool) error {
 		}
 		iptables.OnReloaded(func() {
 			logrus.Debug("Setting the default DROP policy on firewall reload")
-			if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+			if err := iptable.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 				logrus.Warnf("Settig the default DROP policy on firewall reload failed, %v", err)
 			}
 		})

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/docker/libnetwork/iptables"
 	"github.com/sirupsen/logrus"
@@ -16,7 +17,7 @@ const (
 	IsolationChain = "DOCKER-ISOLATION"
 )
 
-func setupIPChains(config *configuration) (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
+func setupIPChains(config *configuration, version iptables.IPVersion) (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
 	// Sanity check.
 	if config.EnableIPTables == false {
 		return nil, nil, nil, errors.New("cannot create new chains, EnableIPTable is disabled")
@@ -24,36 +25,38 @@ func setupIPChains(config *configuration) (*iptables.ChainInfo, *iptables.ChainI
 
 	hairpinMode := !config.EnableUserlandProxy
 
-	natChain, err := iptables.NewChain(DockerChain, iptables.Nat, hairpinMode)
+	iptable := iptables.GetIptable(version)
+
+	natChain, err := iptable.NewChain(DockerChain, iptables.Nat, hairpinMode)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create NAT chain: %v", err)
 	}
 	defer func() {
 		if err != nil {
-			if err := iptables.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
+			if err := iptable.RemoveExistingChain(DockerChain, iptables.Nat); err != nil {
 				logrus.Warnf("failed on removing iptables NAT chain on cleanup: %v", err)
 			}
 		}
 	}()
 
-	filterChain, err := iptables.NewChain(DockerChain, iptables.Filter, false)
+	filterChain, err := iptable.NewChain(DockerChain, iptables.Filter, false)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create FILTER chain: %v", err)
 	}
 	defer func() {
 		if err != nil {
-			if err := iptables.RemoveExistingChain(DockerChain, iptables.Filter); err != nil {
+			if err := iptable.RemoveExistingChain(DockerChain, iptables.Filter); err != nil {
 				logrus.Warnf("failed on removing iptables FILTER chain on cleanup: %v", err)
 			}
 		}
 	}()
 
-	isolationChain, err := iptables.NewChain(IsolationChain, iptables.Filter, false)
+	isolationChain, err := iptable.NewChain(IsolationChain, iptables.Filter, false)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create FILTER isolation chain: %v", err)
 	}
 
-	if err := iptables.AddReturnRule(IsolationChain); err != nil {
+	if err := iptable.AddReturnRule(IsolationChain); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -80,6 +83,9 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 		IP:   i.bridgeIPv4.IP.Mask(i.bridgeIPv4.Mask),
 		Mask: i.bridgeIPv4.Mask,
 	}
+
+	iptable := iptables.GetIptable(iptables.IPv4)
+
 	if config.Internal {
 		if err = setupInternalNetworkRules(config.BridgeName, maskedAddrv4, config.EnableICC, true); err != nil {
 			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
@@ -94,30 +100,84 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 		n.registerIptCleanFunc(func() error {
 			return setupIPTablesInternal(config.BridgeName, maskedAddrv4, config.EnableICC, config.EnableIPMasquerade, hairpinMode, false)
 		})
-		natChain, filterChain, _, err := n.getDriverChains()
+		natChain, filterChain, _, err := n.getDriverChains(iptables.IPv4)
 		if err != nil {
 			return fmt.Errorf("Failed to setup IP tables, cannot acquire chain info %s", err.Error())
 		}
 
-		err = iptables.ProgramChain(natChain, config.BridgeName, hairpinMode, true)
+		err = iptable.ProgramChain(natChain, config.BridgeName, hairpinMode, true)
 		if err != nil {
 			return fmt.Errorf("Failed to program NAT chain: %s", err.Error())
 		}
 
-		err = iptables.ProgramChain(filterChain, config.BridgeName, hairpinMode, true)
+		err = iptable.ProgramChain(filterChain, config.BridgeName, hairpinMode, true)
 		if err != nil {
 			return fmt.Errorf("Failed to program FILTER chain: %s", err.Error())
 		}
 
 		n.registerIptCleanFunc(func() error {
-			return iptables.ProgramChain(filterChain, config.BridgeName, hairpinMode, false)
+			return iptable.ProgramChain(filterChain, config.BridgeName, hairpinMode, false)
 		})
 
 		n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
 	}
 
 	d.Lock()
-	err = iptables.EnsureJumpRule("FORWARD", IsolationChain)
+	err = iptable.EnsureJumpRule("FORWARD", IsolationChain)
+	d.Unlock()
+	if err != nil {
+		return err
+	}
+
+	if !driverConfig.EnableIPv6 || i.bridgeIPv6 == nil {
+		return nil
+	}
+
+	maskedAddrv6 := &net.IPNet{
+		IP:   i.bridgeIPv6.IP.Mask(i.bridgeIPv6.Mask),
+		Mask: i.bridgeIPv6.Mask,
+	}
+
+	iptable = iptables.GetIptable(iptables.IPv6)
+
+	if config.Internal {
+		if err = setupInternalNetworkRules(config.BridgeName, maskedAddrv6, config.EnableICC, true); err != nil {
+			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
+		}
+		n.registerIptCleanFunc(func() error {
+			return setupInternalNetworkRules(config.BridgeName, maskedAddrv6, config.EnableICC, false)
+		})
+	} else {
+		if err = setupIPTablesInternal(config.BridgeName, maskedAddrv6, config.EnableICC, config.EnableIPMasquerade, hairpinMode, true); err != nil {
+			return fmt.Errorf("Failed to Setup IP tables: %s", err.Error())
+		}
+		n.registerIptCleanFunc(func() error {
+			return setupIPTablesInternal(config.BridgeName, maskedAddrv6, config.EnableICC, config.EnableIPMasquerade, hairpinMode, false)
+		})
+		natChainV6, filterChainV6, _, err := n.getDriverChains(iptables.IPv6)
+		if err != nil {
+			return fmt.Errorf("Failed to setup IP tables, cannot acquire chain info %s", err.Error())
+		}
+
+		err = iptable.ProgramChain(natChainV6, config.BridgeName, hairpinMode, true)
+		if err != nil {
+			return fmt.Errorf("Failed to program NAT chain: %s", err.Error())
+		}
+
+		err = iptable.ProgramChain(filterChainV6, config.BridgeName, hairpinMode, true)
+		if err != nil {
+			return fmt.Errorf("Failed to program FILTER chain: %s", err.Error())
+		}
+
+		n.registerIptCleanFunc(func() error {
+			return iptable.ProgramChain(filterChainV6, config.BridgeName, hairpinMode, false)
+		})
+
+		n.portMapperV6.SetIptablesChain(natChainV6, n.getNetworkBridgeName())
+	}
+
+	d.Lock()
+	err = iptable.EnsureJumpRule("FORWARD", IsolationChain)
 	d.Unlock()
 	if err != nil {
 		return err
@@ -143,41 +203,50 @@ func setupIPTablesInternal(bridgeIface string, addr net.Addr, icc, ipmasq, hairp
 		outRule   = iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", bridgeIface, "!", "-o", bridgeIface, "-j", "ACCEPT"}}
 	)
 
+	ipVersion := iptables.IPv4
+
+	if strings.Contains(address, ":") {
+		ipVersion = iptables.IPv6
+	}
+
 	// Set NAT.
 	if ipmasq {
-		if err := programChainRule(natRule, "NAT", enable); err != nil {
+		if err := programChainRule(ipVersion, natRule, "NAT", enable); err != nil {
 			return err
 		}
 	}
 
 	if ipmasq && !hairpin {
-		if err := programChainRule(skipDNAT, "SKIP DNAT", enable); err != nil {
+		if err := programChainRule(ipVersion, skipDNAT, "SKIP DNAT", enable); err != nil {
 			return err
 		}
 	}
 
 	// In hairpin mode, masquerade traffic from localhost
 	if hairpin {
-		if err := programChainRule(hpNatRule, "MASQ LOCAL HOST", enable); err != nil {
+		if err := programChainRule(ipVersion, hpNatRule, "MASQ LOCAL HOST", enable); err != nil {
 			return err
 		}
 	}
 
 	// Set Inter Container Communication.
-	if err := setIcc(bridgeIface, icc, enable); err != nil {
+	if err := setIcc(ipVersion, bridgeIface, icc, enable); err != nil {
 		return err
 	}
 
 	// Set Accept on all non-intercontainer outgoing packets.
-	return programChainRule(outRule, "ACCEPT NON_ICC OUTGOING", enable)
+	return programChainRule(ipVersion, outRule, "ACCEPT NON_ICC OUTGOING", enable)
 }
 
-func programChainRule(rule iptRule, ruleDescr string, insert bool) error {
+func programChainRule(version iptables.IPVersion, rule iptRule, ruleDescr string, insert bool) error {
+
+	iptable := iptables.GetIptable(version)
+
 	var (
 		prefix    []string
 		operation string
 		condition bool
-		doesExist = iptables.Exists(rule.table, rule.chain, rule.args...)
+		doesExist = iptable.Exists(rule.table, rule.chain, rule.args...)
 	)
 
 	if insert {
@@ -194,7 +263,7 @@ func programChainRule(rule iptRule, ruleDescr string, insert bool) error {
 	}
 
 	if condition {
-		if err := iptables.RawCombinedOutput(append(prefix, rule.args...)...); err != nil {
+		if err := iptable.RawCombinedOutput(append(prefix, rule.args...)...); err != nil {
 			return fmt.Errorf("Unable to %s %s rule: %s", operation, ruleDescr, err.Error())
 		}
 	}
@@ -202,7 +271,8 @@ func programChainRule(rule iptRule, ruleDescr string, insert bool) error {
 	return nil
 }
 
-func setIcc(bridgeIface string, iccEnable, insert bool) error {
+func setIcc(version iptables.IPVersion, bridgeIface string, iccEnable, insert bool) error {
+	iptable := iptables.GetIptable(version)
 	var (
 		table      = iptables.Filter
 		chain      = "FORWARD"
@@ -213,18 +283,18 @@ func setIcc(bridgeIface string, iccEnable, insert bool) error {
 
 	if insert {
 		if !iccEnable {
-			iptables.Raw(append([]string{"-D", chain}, acceptArgs...)...)
+			iptable.Raw(append([]string{"-D", chain}, acceptArgs...)...)
 
-			if !iptables.Exists(table, chain, dropArgs...) {
-				if err := iptables.RawCombinedOutput(append([]string{"-A", chain}, dropArgs...)...); err != nil {
+			if !iptable.Exists(table, chain, dropArgs...) {
+				if err := iptable.RawCombinedOutput(append([]string{"-A", chain}, dropArgs...)...); err != nil {
 					return fmt.Errorf("Unable to prevent intercontainer communication: %s", err.Error())
 				}
 			}
 		} else {
-			iptables.Raw(append([]string{"-D", chain}, dropArgs...)...)
+			iptable.Raw(append([]string{"-D", chain}, dropArgs...)...)
 
-			if !iptables.Exists(table, chain, acceptArgs...) {
-				if err := iptables.RawCombinedOutput(append([]string{"-I", chain}, acceptArgs...)...); err != nil {
+			if !iptable.Exists(table, chain, acceptArgs...) {
+				if err := iptable.RawCombinedOutput(append([]string{"-I", chain}, acceptArgs...)...); err != nil {
 					return fmt.Errorf("Unable to allow intercontainer communication: %s", err.Error())
 				}
 			}
@@ -232,12 +302,12 @@ func setIcc(bridgeIface string, iccEnable, insert bool) error {
 	} else {
 		// Remove any ICC rule.
 		if !iccEnable {
-			if iptables.Exists(table, chain, dropArgs...) {
-				iptables.Raw(append([]string{"-D", chain}, dropArgs...)...)
+			if iptable.Exists(table, chain, dropArgs...) {
+				iptable.Raw(append([]string{"-D", chain}, dropArgs...)...)
 			}
 		} else {
-			if iptables.Exists(table, chain, acceptArgs...) {
-				iptables.Raw(append([]string{"-D", chain}, acceptArgs...)...)
+			if iptable.Exists(table, chain, acceptArgs...) {
+				iptable.Raw(append([]string{"-D", chain}, acceptArgs...)...)
 			}
 		}
 	}
@@ -246,7 +316,8 @@ func setIcc(bridgeIface string, iccEnable, insert bool) error {
 }
 
 // Control Inter Network Communication. Install/remove only if it is not/is present.
-func setINC(iface1, iface2 string, enable bool) error {
+func setINC(version iptables.IPVersion, iface1, iface2 string, enable bool) error {
+	iptable := iptables.GetIptable(version)
 	var (
 		table = iptables.Filter
 		chain = IsolationChain
@@ -255,19 +326,19 @@ func setINC(iface1, iface2 string, enable bool) error {
 
 	if enable {
 		for i := 0; i < 2; i++ {
-			if iptables.Exists(table, chain, args[i]...) {
+			if iptable.Exists(table, chain, args[i]...) {
 				continue
 			}
-			if err := iptables.RawCombinedOutput(append([]string{"-I", chain}, args[i]...)...); err != nil {
+			if err := iptable.RawCombinedOutput(append([]string{"-I", chain}, args[i]...)...); err != nil {
 				return fmt.Errorf("unable to add inter-network communication rule: %v", err)
 			}
 		}
 	} else {
 		for i := 0; i < 2; i++ {
-			if !iptables.Exists(table, chain, args[i]...) {
+			if !iptable.Exists(table, chain, args[i]...) {
 				continue
 			}
-			if err := iptables.RawCombinedOutput(append([]string{"-D", chain}, args[i]...)...); err != nil {
+			if err := iptable.RawCombinedOutput(append([]string{"-D", chain}, args[i]...)...); err != nil {
 				return fmt.Errorf("unable to remove inter-network communication rule: %v", err)
 			}
 		}
@@ -276,12 +347,15 @@ func setINC(iface1, iface2 string, enable bool) error {
 	return nil
 }
 
-func removeIPChains() {
+func removeIPChains(version iptables.IPVersion) {
+	ipt := iptables.IPTable{Version: version}
+
 	for _, chainInfo := range []iptables.ChainInfo{
-		{Name: DockerChain, Table: iptables.Nat},
-		{Name: DockerChain, Table: iptables.Filter},
-		{Name: IsolationChain, Table: iptables.Filter},
+		{Name: DockerChain, Table: iptables.Nat, IPTable: ipt},
+		{Name: DockerChain, Table: iptables.Filter, IPTable: ipt},
+		{Name: IsolationChain, Table: iptables.Filter, IPTable: ipt},
 	} {
+
 		if err := chainInfo.Remove(); err != nil {
 			logrus.Warnf("Failed to remove existing iptables entries in table %s chain %s : %v", chainInfo.Table, chainInfo.Name, err)
 		}
@@ -293,14 +367,21 @@ func setupInternalNetworkRules(bridgeIface string, addr net.Addr, icc, insert bo
 		inDropRule  = iptRule{table: iptables.Filter, chain: IsolationChain, args: []string{"-i", bridgeIface, "!", "-d", addr.String(), "-j", "DROP"}}
 		outDropRule = iptRule{table: iptables.Filter, chain: IsolationChain, args: []string{"-o", bridgeIface, "!", "-s", addr.String(), "-j", "DROP"}}
 	)
-	if err := programChainRule(inDropRule, "DROP INCOMING", insert); err != nil {
+
+	version := iptables.IPv4
+
+	if strings.Contains(addr.String(), ":") {
+		version = iptables.IPv6
+	}
+
+	if err := programChainRule(version, inDropRule, "DROP INCOMING", insert); err != nil {
 		return err
 	}
-	if err := programChainRule(outDropRule, "DROP OUTGOING", insert); err != nil {
+	if err := programChainRule(version, outDropRule, "DROP OUTGOING", insert); err != nil {
 		return err
 	}
 	// Set Inter Container Communication.
-	return setIcc(bridgeIface, icc, insert)
+	return setIcc(version, bridgeIface, icc, insert)
 }
 
 func clearEndpointConnections(nlh *netlink.Handle, ep *bridgeEndpoint) {

--- a/drivers/bridge/setup_ip_tables_test.go
+++ b/drivers/bridge/setup_ip_tables_test.go
@@ -96,18 +96,20 @@ func createTestBridge(config *networkConfiguration, br *bridgeInterface, t *test
 // Assert base function which pushes iptables chain rules on insertion and removal.
 func assertIPTableChainProgramming(rule iptRule, descr string, t *testing.T) {
 	// Add
-	if err := programChainRule(rule, descr, true); err != nil {
+	if err := programChainRule(iptables.IPv4, rule, descr, true); err != nil {
 		t.Fatalf("Failed to program iptable rule %s: %s", descr, err.Error())
 	}
-	if iptables.Exists(rule.table, rule.chain, rule.args...) == false {
+
+	iptable := iptables.GetIptable(iptables.IPv4)
+	if iptable.Exists(rule.table, rule.chain, rule.args...) == false {
 		t.Fatalf("Failed to effectively program iptable rule: %s", descr)
 	}
 
 	// Remove
-	if err := programChainRule(rule, descr, false); err != nil {
+	if err := programChainRule(iptables.IPv4, rule, descr, false); err != nil {
 		t.Fatalf("Failed to remove iptable rule %s: %s", descr, err.Error())
 	}
-	if iptables.Exists(rule.table, rule.chain, rule.args...) == true {
+	if iptable.Exists(rule.table, rule.chain, rule.args...) == true {
 		t.Fatalf("Failed to effectively remove iptable rule: %s", descr)
 	}
 }
@@ -116,7 +118,7 @@ func assertIPTableChainProgramming(rule iptRule, descr string, t *testing.T) {
 func assertChainConfig(d *driver, t *testing.T) {
 	var err error
 
-	d.natChain, d.filterChain, d.isolationChain, err = setupIPChains(d.config)
+	d.natChain, d.filterChain, d.isolationChain, err = setupIPChains(d.config, iptables.IPv4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -209,7 +209,9 @@ func programMangle(vni uint32, add bool) (err error) {
 		action = "install"
 	)
 
-	if add == iptables.Exists(iptables.Mangle, chain, rule...) {
+	iptable := iptables.GetIptable(iptables.IPv4)
+
+	if add == iptable.Exists(iptables.Mangle, chain, rule...) {
 		return
 	}
 
@@ -218,7 +220,7 @@ func programMangle(vni uint32, add bool) (err error) {
 		action = "remove"
 	}
 
-	if err = iptables.RawCombinedOutput(append([]string{"-t", string(iptables.Mangle), a, chain}, rule...)...); err != nil {
+	if err = iptable.RawCombinedOutput(append([]string{"-t", string(iptables.Mangle), a, chain}, rule...)...); err != nil {
 		logrus.Warnf("could not %s mangle rule: %v", action, err)
 	}
 
@@ -238,16 +240,18 @@ func programInput(vni uint32, add bool) (err error) {
 		msg        = "add"
 	)
 
+	iptable := iptables.GetIptable(iptables.IPv4)
+
 	if !add {
 		action = iptables.Delete
 		msg = "remove"
 	}
 
-	if err := iptables.ProgramRule(iptables.Filter, chain, action, accept); err != nil {
+	if err := iptable.ProgramRule(iptables.Filter, chain, action, accept); err != nil {
 		logrus.Errorf("could not %s input rule: %v. Please do it manually.", msg, err)
 	}
 
-	if err := iptables.ProgramRule(iptables.Filter, chain, action, block); err != nil {
+	if err := iptable.ProgramRule(iptables.Filter, chain, action, block); err != nil {
 		logrus.Errorf("could not %s input rule: %v. Please do it manually.", msg, err)
 	}
 

--- a/drivers/overlay/filter.go
+++ b/drivers/overlay/filter.go
@@ -20,7 +20,8 @@ func filterWait() func() {
 }
 
 func chainExists(cname string) bool {
-	if _, err := iptables.Raw("-L", cname); err != nil {
+	iptable := iptables.GetIptable(iptables.IPv4)
+	if _, err := iptable.Raw("-L", cname); err != nil {
 		return false
 	}
 
@@ -28,22 +29,24 @@ func chainExists(cname string) bool {
 }
 
 func setupGlobalChain() {
+	iptable := iptables.GetIptable(iptables.IPv4)
 	// Because of an ungraceful shutdown, chain could already be present
 	if !chainExists(globalChain) {
-		if err := iptables.RawCombinedOutput("-N", globalChain); err != nil {
+		if err := iptable.RawCombinedOutput("-N", globalChain); err != nil {
 			logrus.Errorf("could not create global overlay chain: %v", err)
 			return
 		}
 	}
 
-	if !iptables.Exists(iptables.Filter, globalChain, "-j", "RETURN") {
-		if err := iptables.RawCombinedOutput("-A", globalChain, "-j", "RETURN"); err != nil {
+	if !iptable.Exists(iptables.Filter, globalChain, "-j", "RETURN") {
+		if err := iptable.RawCombinedOutput("-A", globalChain, "-j", "RETURN"); err != nil {
 			logrus.Errorf("could not install default return chain in the overlay global chain: %v", err)
 		}
 	}
 }
 
 func setNetworkChain(cname string, remove bool) error {
+	iptable := iptables.GetIptable(iptables.IPv4)
 	// Initialize the onetime global overlay chain
 	filterOnce.Do(setupGlobalChain)
 
@@ -52,21 +55,21 @@ func setNetworkChain(cname string, remove bool) error {
 	opt := "-N"
 	// In case of remove, make sure to flush the rules in the chain
 	if remove && exists {
-		if err := iptables.RawCombinedOutput("-F", cname); err != nil {
+		if err := iptable.RawCombinedOutput("-F", cname); err != nil {
 			return fmt.Errorf("failed to flush overlay network chain %s rules: %v", cname, err)
 		}
 		opt = "-X"
 	}
 
 	if (!remove && !exists) || (remove && exists) {
-		if err := iptables.RawCombinedOutput(opt, cname); err != nil {
+		if err := iptable.RawCombinedOutput(opt, cname); err != nil {
 			return fmt.Errorf("failed network chain operation %q for chain %s: %v", opt, cname, err)
 		}
 	}
 
 	if !remove {
-		if !iptables.Exists(iptables.Filter, cname, "-j", "DROP") {
-			if err := iptables.RawCombinedOutput("-A", cname, "-j", "DROP"); err != nil {
+		if !iptable.Exists(iptables.Filter, cname, "-j", "DROP") {
+			if err := iptable.RawCombinedOutput("-A", cname, "-j", "DROP"); err != nil {
 				return fmt.Errorf("failed adding default drop rule to overlay network chain %s: %v", cname, err)
 			}
 		}
@@ -92,37 +95,38 @@ func setFilters(cname, brName string, remove bool) error {
 	if remove {
 		opt = "-D"
 	}
+	iptable := iptables.GetIptable(iptables.IPv4)
 
 	// Every time we set filters for a new subnet make sure to move the global overlay hook to the top of the both the OUTPUT and forward chains
 	if !remove {
 		for _, chain := range []string{"OUTPUT", "FORWARD"} {
-			exists := iptables.Exists(iptables.Filter, chain, "-j", globalChain)
+			exists := iptable.Exists(iptables.Filter, chain, "-j", globalChain)
 			if exists {
-				if err := iptables.RawCombinedOutput("-D", chain, "-j", globalChain); err != nil {
+				if err := iptable.RawCombinedOutput("-D", chain, "-j", globalChain); err != nil {
 					return fmt.Errorf("failed to delete overlay hook in chain %s while moving the hook: %v", chain, err)
 				}
 			}
 
-			if err := iptables.RawCombinedOutput("-I", chain, "-j", globalChain); err != nil {
+			if err := iptable.RawCombinedOutput("-I", chain, "-j", globalChain); err != nil {
 				return fmt.Errorf("failed to insert overlay hook in chain %s: %v", chain, err)
 			}
 		}
 	}
 
 	// Insert/Delete the rule to jump to per-bridge chain
-	exists := iptables.Exists(iptables.Filter, globalChain, "-o", brName, "-j", cname)
+	exists := iptable.Exists(iptables.Filter, globalChain, "-o", brName, "-j", cname)
 	if (!remove && !exists) || (remove && exists) {
-		if err := iptables.RawCombinedOutput(opt, globalChain, "-o", brName, "-j", cname); err != nil {
+		if err := iptable.RawCombinedOutput(opt, globalChain, "-o", brName, "-j", cname); err != nil {
 			return fmt.Errorf("failed to add per-bridge filter rule for bridge %s, network chain %s: %v", brName, cname, err)
 		}
 	}
 
-	exists = iptables.Exists(iptables.Filter, cname, "-i", brName, "-j", "ACCEPT")
+	exists = iptable.Exists(iptables.Filter, cname, "-i", brName, "-j", "ACCEPT")
 	if (!remove && exists) || (remove && !exists) {
 		return nil
 	}
 
-	if err := iptables.RawCombinedOutput(opt, cname, "-i", brName, "-j", "ACCEPT"); err != nil {
+	if err := iptable.RawCombinedOutput(opt, cname, "-i", brName, "-j", "ACCEPT"); err != nil {
 		return fmt.Errorf("failed to add overlay filter rile for network chain %s, bridge %s: %v", cname, brName, err)
 	}
 

--- a/firewall_linux.go
+++ b/firewall_linux.go
@@ -11,18 +11,19 @@ const userChain = "DOCKER-USER"
 // docker operations/restarts. Docker will not delete or modify any pre-existing
 // rules from the DOCKER-USER filter chain.
 func arrangeUserFilterRule() {
-	_, err := iptables.NewChain(userChain, iptables.Filter, false)
+	iptable := iptables.GetIptable(iptables.IPv4)
+	_, err := iptable.NewChain(userChain, iptables.Filter, false)
 	if err != nil {
 		logrus.Warnf("Failed to create %s chain: %v", userChain, err)
 		return
 	}
 
-	if err = iptables.AddReturnRule(userChain); err != nil {
+	if err = iptable.AddReturnRule(userChain); err != nil {
 		logrus.Warnf("Failed to add the RETURN rule for %s: %v", userChain, err)
 		return
 	}
 
-	err = iptables.EnsureJumpRule("FORWARD", userChain)
+	err = iptable.EnsureJumpRule("FORWARD", userChain)
 	if err != nil {
 		logrus.Warnf("Failed to ensure the jump rule for %s: %v", userChain, err)
 	}

--- a/iptables/firewalld_test.go
+++ b/iptables/firewalld_test.go
@@ -19,13 +19,14 @@ func TestReloaded(t *testing.T) {
 	var err error
 	var fwdChain *ChainInfo
 
-	fwdChain, err = NewChain("FWD", Filter, false)
+	iptable := GetIptable(IPv4)
+	fwdChain, err = iptable.NewChain("FWD", Filter, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bridgeName := "lo"
 
-	err = ProgramChain(fwdChain, bridgeName, false, true)
+	err = iptable.ProgramChain(fwdChain, bridgeName, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +55,7 @@ func TestReloaded(t *testing.T) {
 		"--dport", strconv.Itoa(port),
 		"-j", "ACCEPT"}
 
-	if !Exists(fwdChain.Table, fwdChain.Name, rule1...) {
+	if !iptable.Exists(fwdChain.Table, fwdChain.Name, rule1...) {
 		t.Fatal("rule1 does not exist")
 	}
 
@@ -64,7 +65,7 @@ func TestReloaded(t *testing.T) {
 	reloaded()
 
 	// make sure the rules have been recreated
-	if !Exists(fwdChain.Table, fwdChain.Name, rule1...) {
+	if !iptable.Exists(fwdChain.Table, fwdChain.Name, rule1...) {
 		t.Fatal("rule1 hasn't been recreated")
 	}
 }
@@ -76,12 +77,13 @@ func TestPassthrough(t *testing.T) {
 		"--dport", "123",
 		"-j", "ACCEPT"}
 
+	iptable := GetIptable(IPv4)
 	if firewalldRunning {
 		_, err := Passthrough(Iptables, append([]string{"-A"}, rule1...)...)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !Exists(Filter, "INPUT", rule1...) {
+		if !iptable.Exists(Filter, "INPUT", rule1...) {
 			t.Fatal("rule1 does not exist")
 		}
 	}

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -22,6 +22,9 @@ type Policy string
 // Table refers to Nat, Filter or Mangle.
 type Table string
 
+// IPVersion refers to IP version, v4 or v6
+type IPVersion string
+
 const (
 	// Append appends the rule at the end of the chain.
 	Append Action = "-A"
@@ -39,10 +42,15 @@ const (
 	Drop Policy = "DROP"
 	// Accept is the default iptables ACCEPT policy
 	Accept Policy = "ACCEPT"
+	// IPv4 is version 4
+	IPv4 IPVersion = "IPV4"
+	// IPv6 is version 6
+	IPv6 IPVersion = "IPV6"
 )
 
 var (
 	iptablesPath  string
+	ip6tablesPath string
 	supportsXlock = false
 	supportsCOpt  = false
 	xLockWaitMsg  = "Another app is currently holding the xtables lock; waiting"
@@ -53,11 +61,17 @@ var (
 	initOnce            sync.Once
 )
 
+// IPTable defines struct with IPVersion and few other members are added later
+type IPTable struct {
+	Version IPVersion
+}
+
 // ChainInfo defines the iptables chain.
 type ChainInfo struct {
 	Name        string
 	Table       Table
 	HairpinMode bool
+	IPTable     IPTable
 }
 
 // ChainError is returned to represent errors during ip table operation.
@@ -91,6 +105,11 @@ func detectIptables() {
 		return
 	}
 	iptablesPath = path
+	path, err = exec.LookPath("ip6tables")
+	if err != nil {
+		return
+	}
+	ip6tablesPath = path
 	supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	mj, mn, mc, err := GetVersion()
 	if err != nil {
@@ -115,20 +134,26 @@ func initCheck() error {
 	return nil
 }
 
+// GetIptable returns an instance of IPTable with specified version
+func GetIptable(version IPVersion) *IPTable {
+	return &IPTable{Version: version}
+}
+
 // NewChain adds a new chain to ip table.
-func NewChain(name string, table Table, hairpinMode bool) (*ChainInfo, error) {
+func (iptable IPTable) NewChain(name string, table Table, hairpinMode bool) (*ChainInfo, error) {
 	c := &ChainInfo{
 		Name:        name,
 		Table:       table,
 		HairpinMode: hairpinMode,
+		IPTable:     iptable,
 	}
 	if string(c.Table) == "" {
 		c.Table = Filter
 	}
 
 	// Add chain if it doesn't exist
-	if _, err := Raw("-t", string(c.Table), "-n", "-L", c.Name); err != nil {
-		if output, err := Raw("-t", string(c.Table), "-N", c.Name); err != nil {
+	if _, err := iptable.Raw("-t", string(c.Table), "-n", "-L", c.Name); err != nil {
+		if output, err := iptable.Raw("-t", string(c.Table), "-N", c.Name); err != nil {
 			return nil, err
 		} else if len(output) != 0 {
 			return nil, fmt.Errorf("Could not create %s/%s chain: %s", c.Table, c.Name, output)
@@ -137,8 +162,16 @@ func NewChain(name string, table Table, hairpinMode bool) (*ChainInfo, error) {
 	return c, nil
 }
 
+// LoopbackByVersion returns loopback address by version
+func (iptable IPTable) LoopbackByVersion() string {
+	if iptable.Version == IPv6 {
+		return "::1/128"
+	}
+	return "127.0.0.0/8"
+}
+
 // ProgramChain is used to add rules to a chain
-func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) error {
+func (iptable IPTable) ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) error {
 	if c.Name == "" {
 		return errors.New("Could not program chain, missing chain name")
 	}
@@ -149,11 +182,11 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 			"-m", "addrtype",
 			"--dst-type", "LOCAL",
 			"-j", c.Name}
-		if !Exists(Nat, "PREROUTING", preroute...) && enable {
+		if !iptable.Exists(Nat, "PREROUTING", preroute...) && enable {
 			if err := c.Prerouting(Append, preroute...); err != nil {
 				return fmt.Errorf("Failed to inject %s in PREROUTING chain: %s", c.Name, err)
 			}
-		} else if Exists(Nat, "PREROUTING", preroute...) && !enable {
+		} else if iptable.Exists(Nat, "PREROUTING", preroute...) && !enable {
 			if err := c.Prerouting(Delete, preroute...); err != nil {
 				return fmt.Errorf("Failed to remove %s in PREROUTING chain: %s", c.Name, err)
 			}
@@ -163,13 +196,13 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 			"--dst-type", "LOCAL",
 			"-j", c.Name}
 		if !hairpinMode {
-			output = append(output, "!", "--dst", "127.0.0.0/8")
+			output = append(output, "!", "--dst", iptable.LoopbackByVersion())
 		}
-		if !Exists(Nat, "OUTPUT", output...) && enable {
+		if !iptable.Exists(Nat, "OUTPUT", output...) && enable {
 			if err := c.Output(Append, output...); err != nil {
 				return fmt.Errorf("Failed to inject %s in OUTPUT chain: %s", c.Name, err)
 			}
-		} else if Exists(Nat, "OUTPUT", output...) && !enable {
+		} else if iptable.Exists(Nat, "OUTPUT", output...) && !enable {
 			if err := c.Output(Delete, output...); err != nil {
 				return fmt.Errorf("Failed to inject %s in OUTPUT chain: %s", c.Name, err)
 			}
@@ -182,16 +215,16 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 		link := []string{
 			"-o", bridgeName,
 			"-j", c.Name}
-		if !Exists(Filter, "FORWARD", link...) && enable {
+		if !iptable.Exists(Filter, "FORWARD", link...) && enable {
 			insert := append([]string{string(Insert), "FORWARD"}, link...)
-			if output, err := Raw(insert...); err != nil {
+			if output, err := iptable.Raw(insert...); err != nil {
 				return err
 			} else if len(output) != 0 {
 				return fmt.Errorf("Could not create linking rule to %s/%s: %s", c.Table, c.Name, output)
 			}
-		} else if Exists(Filter, "FORWARD", link...) && !enable {
+		} else if iptable.Exists(Filter, "FORWARD", link...) && !enable {
 			del := append([]string{string(Delete), "FORWARD"}, link...)
-			if output, err := Raw(del...); err != nil {
+			if output, err := iptable.Raw(del...); err != nil {
 				return err
 			} else if len(output) != 0 {
 				return fmt.Errorf("Could not delete linking rule from %s/%s: %s", c.Table, c.Name, output)
@@ -203,16 +236,16 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 			"-m", "conntrack",
 			"--ctstate", "RELATED,ESTABLISHED",
 			"-j", "ACCEPT"}
-		if !Exists(Filter, "FORWARD", establish...) && enable {
+		if !iptable.Exists(Filter, "FORWARD", establish...) && enable {
 			insert := append([]string{string(Insert), "FORWARD"}, establish...)
-			if output, err := Raw(insert...); err != nil {
+			if output, err := iptable.Raw(insert...); err != nil {
 				return err
 			} else if len(output) != 0 {
 				return fmt.Errorf("Could not create establish rule to %s: %s", c.Table, output)
 			}
-		} else if Exists(Filter, "FORWARD", establish...) && !enable {
+		} else if iptable.Exists(Filter, "FORWARD", establish...) && !enable {
 			del := append([]string{string(Delete), "FORWARD"}, establish...)
-			if output, err := Raw(del...); err != nil {
+			if output, err := iptable.Raw(del...); err != nil {
 				return err
 			} else if len(output) != 0 {
 				return fmt.Errorf("Could not delete establish rule from %s: %s", c.Table, output)
@@ -223,10 +256,11 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 }
 
 // RemoveExistingChain removes existing chain from the table.
-func RemoveExistingChain(name string, table Table) error {
+func (iptable IPTable) RemoveExistingChain(name string, table Table) error {
 	c := &ChainInfo{
-		Name:  name,
-		Table: table,
+		Name:    name,
+		Table:   table,
+		IPTable: iptable,
 	}
 	if string(c.Table) == "" {
 		c.Table = Filter
@@ -236,6 +270,8 @@ func RemoveExistingChain(name string, table Table) error {
 
 // Forward adds forwarding rule to 'filter' table and corresponding nat rule to 'nat' table.
 func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr string, destPort int, bridgeName string) error {
+
+	iptable := GetIptable(c.IPTable.Version)
 	daddr := ip.String()
 	if ip.IsUnspecified() {
 		// iptables interprets "0.0.0.0" as "0.0.0.0/32", whereas we
@@ -250,10 +286,11 @@ func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr 
 		"--dport", strconv.Itoa(port),
 		"-j", "DNAT",
 		"--to-destination", net.JoinHostPort(destAddr, strconv.Itoa(destPort))}
+
 	if !c.HairpinMode {
 		args = append(args, "!", "-i", bridgeName)
 	}
-	if err := ProgramRule(Nat, c.Name, action, args); err != nil {
+	if err := iptable.ProgramRule(Nat, c.Name, action, args); err != nil {
 		return err
 	}
 
@@ -265,7 +302,7 @@ func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr 
 		"--dport", strconv.Itoa(destPort),
 		"-j", "ACCEPT",
 	}
-	if err := ProgramRule(Filter, c.Name, action, args); err != nil {
+	if err := iptable.ProgramRule(Filter, c.Name, action, args); err != nil {
 		return err
 	}
 
@@ -276,12 +313,13 @@ func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr 
 		"--dport", strconv.Itoa(destPort),
 		"-j", "MASQUERADE",
 	}
-	return ProgramRule(Nat, "POSTROUTING", action, args)
+	return iptable.ProgramRule(Nat, "POSTROUTING", action, args)
 }
 
 // Link adds reciprocal ACCEPT rule for two supplied IP addresses.
 // Traffic is allowed from ip1 to ip2 and vice-versa
 func (c *ChainInfo) Link(action Action, ip1, ip2 net.IP, port int, proto string, bridgeName string) error {
+	iptable := GetIptable(c.IPTable.Version)
 	// forward
 	args := []string{
 		"-i", bridgeName, "-o", bridgeName,
@@ -291,32 +329,34 @@ func (c *ChainInfo) Link(action Action, ip1, ip2 net.IP, port int, proto string,
 		"--dport", strconv.Itoa(port),
 		"-j", "ACCEPT",
 	}
-	if err := ProgramRule(Filter, c.Name, action, args); err != nil {
+
+	if err := iptable.ProgramRule(Filter, c.Name, action, args); err != nil {
 		return err
 	}
 	// reverse
 	args[7], args[9] = args[9], args[7]
 	args[10] = "--sport"
-	return ProgramRule(Filter, c.Name, action, args)
+	return iptable.ProgramRule(Filter, c.Name, action, args)
 }
 
 // ProgramRule adds the rule specified by args only if the
 // rule is not already present in the chain. Reciprocally,
 // it removes the rule only if present.
-func ProgramRule(table Table, chain string, action Action, args []string) error {
-	if Exists(table, chain, args...) != (action == Delete) {
+func (iptable IPTable) ProgramRule(table Table, chain string, action Action, args []string) error {
+	if iptable.Exists(table, chain, args...) != (action == Delete) {
 		return nil
 	}
-	return RawCombinedOutput(append([]string{"-t", string(table), string(action), chain}, args...)...)
+	return iptable.RawCombinedOutput(append([]string{"-t", string(table), string(action), chain}, args...)...)
 }
 
 // Prerouting adds linking rule to nat/PREROUTING chain.
 func (c *ChainInfo) Prerouting(action Action, args ...string) error {
+	iptable := GetIptable(c.IPTable.Version)
 	a := []string{"-t", string(Nat), string(action), "PREROUTING"}
 	if len(args) > 0 {
 		a = append(a, args...)
 	}
-	if output, err := Raw(a...); err != nil {
+	if output, err := iptable.Raw(a...); err != nil {
 		return err
 	} else if len(output) != 0 {
 		return ChainError{Chain: "PREROUTING", Output: output}
@@ -326,11 +366,12 @@ func (c *ChainInfo) Prerouting(action Action, args ...string) error {
 
 // Output adds linking rule to an OUTPUT chain.
 func (c *ChainInfo) Output(action Action, args ...string) error {
+	iptable := GetIptable(c.IPTable.Version)
 	a := []string{"-t", string(c.Table), string(action), "OUTPUT"}
 	if len(args) > 0 {
 		a = append(a, args...)
 	}
-	if output, err := Raw(a...); err != nil {
+	if output, err := iptable.Raw(a...); err != nil {
 		return err
 	} else if len(output) != 0 {
 		return ChainError{Chain: "OUTPUT", Output: output}
@@ -340,35 +381,36 @@ func (c *ChainInfo) Output(action Action, args ...string) error {
 
 // Remove removes the chain.
 func (c *ChainInfo) Remove() error {
+	iptable := GetIptable(c.IPTable.Version)
 	// Ignore errors - This could mean the chains were never set up
 	if c.Table == Nat {
 		c.Prerouting(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name)
-		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "!", "--dst", "127.0.0.0/8", "-j", c.Name)
+		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "!", "--dst", iptable.LoopbackByVersion(), "-j", c.Name)
 		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name) // Created in versions <= 0.1.6
 
 		c.Prerouting(Delete)
 		c.Output(Delete)
 	}
-	Raw("-t", string(c.Table), "-F", c.Name)
-	Raw("-t", string(c.Table), "-X", c.Name)
+	iptable.Raw("-t", string(c.Table), "-F", c.Name)
+	iptable.Raw("-t", string(c.Table), "-X", c.Name)
 	return nil
 }
 
 // Exists checks if a rule exists
-func Exists(table Table, chain string, rule ...string) bool {
-	return exists(false, table, chain, rule...)
+func (iptable IPTable) Exists(table Table, chain string, rule ...string) bool {
+	return iptable.exists(false, table, chain, rule...)
 }
 
 // ExistsNative behaves as Exists with the difference it
 // will always invoke `iptables` binary.
-func ExistsNative(table Table, chain string, rule ...string) bool {
-	return exists(true, table, chain, rule...)
+func (iptable IPTable) ExistsNative(table Table, chain string, rule ...string) bool {
+	return iptable.exists(true, table, chain, rule...)
 }
 
-func exists(native bool, table Table, chain string, rule ...string) bool {
-	f := Raw
+func (iptable IPTable) exists(native bool, table Table, chain string, rule ...string) bool {
+	f := iptable.Raw
 	if native {
-		f = raw
+		f = iptable.raw
 	}
 
 	if string(table) == "" {
@@ -389,28 +431,32 @@ func exists(native bool, table Table, chain string, rule ...string) bool {
 
 	// parse "iptables -S" for the rule (it checks rules in a specific chain
 	// in a specific table and it is very unreliable)
-	return existsRaw(table, chain, rule...)
+	return iptable.existsRaw(table, chain, rule...)
 }
 
-func existsRaw(table Table, chain string, rule ...string) bool {
+func (iptable IPTable) existsRaw(table Table, chain string, rule ...string) bool {
+	path := iptablesPath
+	if iptable.Version == IPv6 {
+		path = ip6tablesPath
+	}
 	ruleString := fmt.Sprintf("%s %s\n", chain, strings.Join(rule, " "))
-	existingRules, _ := exec.Command(iptablesPath, "-t", string(table), "-S", chain).Output()
+	existingRules, _ := exec.Command(path, "-t", string(table), "-S", chain).Output()
 
 	return strings.Contains(string(existingRules), ruleString)
 }
 
 // Raw calls 'iptables' system command, passing supplied arguments.
-func Raw(args ...string) ([]byte, error) {
+func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalldRunning {
 		output, err := Passthrough(Iptables, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
 			return output, err
 		}
 	}
-	return raw(args...)
+	return iptable.raw(args...)
 }
 
-func raw(args ...string) ([]byte, error) {
+func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	if err := initCheck(); err != nil {
 		return nil, err
 	}
@@ -421,9 +467,14 @@ func raw(args ...string) ([]byte, error) {
 		defer bestEffortLock.Unlock()
 	}
 
-	logrus.Debugf("%s, %v", iptablesPath, args)
+	path := iptablesPath
+	if iptable.Version == IPv6 {
+		path = ip6tablesPath
+	}
 
-	output, err := exec.Command(iptablesPath, args...).CombinedOutput()
+	logrus.Debugf("%s, %v", path, args)
+
+	output, err := exec.Command(path, args...).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("iptables failed: iptables %v: %s (%s)", strings.Join(args, " "), output, err)
 	}
@@ -438,8 +489,8 @@ func raw(args ...string) ([]byte, error) {
 
 // RawCombinedOutput inernally calls the Raw function and returns a non nil
 // error if Raw returned a non nil error or a non empty output
-func RawCombinedOutput(args ...string) error {
-	if output, err := Raw(args...); err != nil || len(output) != 0 {
+func (iptable IPTable) RawCombinedOutput(args ...string) error {
+	if output, err := iptable.Raw(args...); err != nil || len(output) != 0 {
 		return fmt.Errorf("%s (%v)", string(output), err)
 	}
 	return nil
@@ -447,16 +498,16 @@ func RawCombinedOutput(args ...string) error {
 
 // RawCombinedOutputNative behave as RawCombinedOutput with the difference it
 // will always invoke `iptables` binary
-func RawCombinedOutputNative(args ...string) error {
-	if output, err := raw(args...); err != nil || len(output) != 0 {
+func (iptable IPTable) RawCombinedOutputNative(args ...string) error {
+	if output, err := iptable.raw(args...); err != nil || len(output) != 0 {
 		return fmt.Errorf("%s (%v)", string(output), err)
 	}
 	return nil
 }
 
 // ExistChain checks if a chain exists
-func ExistChain(chain string, table Table) bool {
-	if _, err := Raw("-t", string(table), "-nL", chain); err == nil {
+func (iptable IPTable) ExistChain(chain string, table Table) bool {
+	if _, err := iptable.Raw("-t", string(table), "-nL", chain); err == nil {
 		return true
 	}
 	return false
@@ -472,8 +523,8 @@ func GetVersion() (major, minor, micro int, err error) {
 }
 
 // SetDefaultPolicy sets the passed default policy for the table/chain
-func SetDefaultPolicy(table Table, chain string, policy Policy) error {
-	if err := RawCombinedOutput("-t", string(table), "-P", chain, string(policy)); err != nil {
+func (iptable IPTable) SetDefaultPolicy(table Table, chain string, policy Policy) error {
+	if err := iptable.RawCombinedOutput("-t", string(table), "-P", chain, string(policy)); err != nil {
 		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
 	}
 	return nil
@@ -493,17 +544,17 @@ func supportsCOption(mj, mn, mc int) bool {
 }
 
 // AddReturnRule adds a return rule for the chain in the filter table
-func AddReturnRule(chain string) error {
+func (iptable IPTable) AddReturnRule(chain string) error {
 	var (
 		table = Filter
 		args  = []string{"-j", "RETURN"}
 	)
 
-	if Exists(table, chain, args...) {
+	if iptable.Exists(table, chain, args...) {
 		return nil
 	}
 
-	err := RawCombinedOutput(append([]string{"-A", chain}, args...)...)
+	err := iptable.RawCombinedOutput(append([]string{"-A", chain}, args...)...)
 	if err != nil {
 		return fmt.Errorf("unable to add return rule in %s chain: %s", chain, err.Error())
 	}
@@ -512,20 +563,20 @@ func AddReturnRule(chain string) error {
 }
 
 // EnsureJumpRule ensures the jump rule is on top
-func EnsureJumpRule(fromChain, toChain string) error {
+func (iptable IPTable) EnsureJumpRule(fromChain, toChain string) error {
 	var (
 		table = Filter
 		args  = []string{"-j", toChain}
 	)
 
-	if Exists(table, fromChain, args...) {
-		err := RawCombinedOutput(append([]string{"-D", fromChain}, args...)...)
+	if iptable.Exists(table, fromChain, args...) {
+		err := iptable.RawCombinedOutput(append([]string{"-D", fromChain}, args...)...)
 		if err != nil {
 			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
 		}
 	}
 
-	err := RawCombinedOutput(append([]string{"-I", fromChain}, args...)...)
+	err := iptable.RawCombinedOutput(append([]string{"-I", fromChain}, args...)...)
 	if err != nil {
 		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
 	}

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -194,7 +194,7 @@ func TestBridge(t *testing.T) {
 	if !ok {
 		t.Fatalf("Unexpected format for port mapping in endpoint operational data")
 	}
-	if len(pm) != 5 {
+	if len(pm) != 10 {
 		t.Fatalf("Incomplete data for port mapping in endpoint operational data: %d", len(pm))
 	}
 }

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -137,7 +137,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	}
 
 	containerIP, containerPort := getIPAndPort(m.container)
-	if hostIP.To4() != nil {
+	if hostIP.To4() != nil || hostIP.To16() != nil {
 		if err := pm.forward(iptables.Append, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
 			return nil, err
 		}
@@ -156,11 +156,13 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 		return nil
 	}
 
-	if err := m.userlandProxy.Start(); err != nil {
-		if err := cleanup(); err != nil {
-			return nil, fmt.Errorf("Error during port allocation cleanup: %v", err)
+	if hostIP.To4() != nil {
+		if err := m.userlandProxy.Start(); err != nil {
+			if err := cleanup(); err != nil {
+				return nil, fmt.Errorf("Error during port allocation cleanup: %v", err)
+			}
+			return nil, err
 		}
-		return nil, err
 	}
 
 	pm.currentMappings[key] = m

--- a/resolver_unix.go
+++ b/resolver_unix.go
@@ -57,25 +57,27 @@ func reexecSetupResolver() {
 		os.Exit(3)
 	}
 
+	iptable := iptables.GetIptable(iptables.IPv4)
+
 	// insert outputChain and postroutingchain
-	err = iptables.RawCombinedOutputNative("-t", "nat", "-C", "OUTPUT", "-d", resolverIP, "-j", outputChain)
+	err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "OUTPUT", "-d", resolverIP, "-j", outputChain)
 	if err == nil {
-		iptables.RawCombinedOutputNative("-t", "nat", "-F", outputChain)
+		iptable.RawCombinedOutputNative("-t", "nat", "-F", outputChain)
 	} else {
-		iptables.RawCombinedOutputNative("-t", "nat", "-N", outputChain)
-		iptables.RawCombinedOutputNative("-t", "nat", "-I", "OUTPUT", "-d", resolverIP, "-j", outputChain)
+		iptable.RawCombinedOutputNative("-t", "nat", "-N", outputChain)
+		iptable.RawCombinedOutputNative("-t", "nat", "-I", "OUTPUT", "-d", resolverIP, "-j", outputChain)
 	}
 
-	err = iptables.RawCombinedOutputNative("-t", "nat", "-C", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
+	err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
 	if err == nil {
-		iptables.RawCombinedOutputNative("-t", "nat", "-F", postroutingchain)
+		iptable.RawCombinedOutputNative("-t", "nat", "-F", postroutingchain)
 	} else {
-		iptables.RawCombinedOutputNative("-t", "nat", "-N", postroutingchain)
-		iptables.RawCombinedOutputNative("-t", "nat", "-I", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
+		iptable.RawCombinedOutputNative("-t", "nat", "-N", postroutingchain)
+		iptable.RawCombinedOutputNative("-t", "nat", "-I", "POSTROUTING", "-d", resolverIP, "-j", postroutingchain)
 	}
 
 	for _, rule := range rules {
-		if iptables.RawCombinedOutputNative(rule...) != nil {
+		if iptable.RawCombinedOutputNative(rule...) != nil {
 			logrus.Errorf("setting up rule failed, %v", rule)
 		}
 	}

--- a/service_linux.go
+++ b/service_linux.go
@@ -313,24 +313,27 @@ func filterPortConfigs(ingressPorts []*PortConfig, isDelete bool) []*PortConfig 
 }
 
 func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) error {
+
+	iptable := iptables.GetIptable(iptables.IPv4)
+
 	addDelOpt := "-I"
 	if isDelete {
 		addDelOpt = "-D"
 	}
 
-	chainExists := iptables.ExistChain(ingressChain, iptables.Nat)
-	filterChainExists := iptables.ExistChain(ingressChain, iptables.Filter)
+	chainExists := iptable.ExistChain(ingressChain, iptables.Nat)
+	filterChainExists := iptable.ExistChain(ingressChain, iptables.Filter)
 
 	ingressOnce.Do(func() {
 		// Flush nat table and filter table ingress chain rules during init if it
 		// exists. It might contain stale rules from previous life.
 		if chainExists {
-			if err := iptables.RawCombinedOutput("-t", "nat", "-F", ingressChain); err != nil {
+			if err := iptable.RawCombinedOutput("-t", "nat", "-F", ingressChain); err != nil {
 				logrus.Errorf("Could not flush nat table ingress chain rules during init: %v", err)
 			}
 		}
 		if filterChainExists {
-			if err := iptables.RawCombinedOutput("-F", ingressChain); err != nil {
+			if err := iptable.RawCombinedOutput("-F", ingressChain); err != nil {
 				logrus.Errorf("Could not flush filter table ingress chain rules during init: %v", err)
 			}
 		}
@@ -338,41 +341,40 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 
 	if !isDelete {
 		if !chainExists {
-			if err := iptables.RawCombinedOutput("-t", "nat", "-N", ingressChain); err != nil {
+			if err := iptable.RawCombinedOutput("-t", "nat", "-N", ingressChain); err != nil {
 				return fmt.Errorf("failed to create ingress chain: %v", err)
 			}
 		}
 		if !filterChainExists {
-			if err := iptables.RawCombinedOutput("-N", ingressChain); err != nil {
+			if err := iptable.RawCombinedOutput("-N", ingressChain); err != nil {
 				return fmt.Errorf("failed to create filter table ingress chain: %v", err)
 			}
 		}
 
-		if !iptables.Exists(iptables.Nat, ingressChain, "-j", "RETURN") {
-			if err := iptables.RawCombinedOutput("-t", "nat", "-A", ingressChain, "-j", "RETURN"); err != nil {
+		if !iptable.Exists(iptables.Nat, ingressChain, "-j", "RETURN") {
+			if err := iptable.RawCombinedOutput("-t", "nat", "-A", ingressChain, "-j", "RETURN"); err != nil {
 				return fmt.Errorf("failed to add return rule in nat table ingress chain: %v", err)
 			}
 		}
 
-		if !iptables.Exists(iptables.Filter, ingressChain, "-j", "RETURN") {
-			if err := iptables.RawCombinedOutput("-A", ingressChain, "-j", "RETURN"); err != nil {
+		if !iptable.Exists(iptables.Filter, ingressChain, "-j", "RETURN") {
+			if err := iptable.RawCombinedOutput("-A", ingressChain, "-j", "RETURN"); err != nil {
 				return fmt.Errorf("failed to add return rule to filter table ingress chain: %v", err)
 			}
 		}
 
 		for _, chain := range []string{"OUTPUT", "PREROUTING"} {
-			if !iptables.Exists(iptables.Nat, chain, "-m", "addrtype", "--dst-type", "LOCAL", "-j", ingressChain) {
-				if err := iptables.RawCombinedOutput("-t", "nat", "-I", chain, "-m", "addrtype", "--dst-type", "LOCAL", "-j", ingressChain); err != nil {
+			if !iptable.Exists(iptables.Nat, chain, "-m", "addrtype", "--dst-type", "LOCAL", "-j", ingressChain) {
+				if err := iptable.RawCombinedOutput("-t", "nat", "-I", chain, "-m", "addrtype", "--dst-type", "LOCAL", "-j", ingressChain); err != nil {
 					return fmt.Errorf("failed to add jump rule in %s to ingress chain: %v", chain, err)
 				}
 			}
 		}
 
-		if !iptables.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
-			if err := iptables.RawCombinedOutput("-I", "FORWARD", "-j", ingressChain); err != nil {
+		if !iptable.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
+			if err := iptable.RawCombinedOutput("-I", "FORWARD", "-j", ingressChain); err != nil {
 				return fmt.Errorf("failed to add jump rule to %s in filter table forward chain: %v", ingressChain, err)
 			}
-			arrangeUserFilterRule()
 		}
 
 		oifName, err := findOIFName(gwIP)
@@ -386,18 +388,18 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 		}
 
 		ruleArgs := strings.Fields(fmt.Sprintf("-m addrtype --src-type LOCAL -o %s -j MASQUERADE", oifName))
-		if !iptables.Exists(iptables.Nat, "POSTROUTING", ruleArgs...) {
-			if err := iptables.RawCombinedOutput(append([]string{"-t", "nat", "-I", "POSTROUTING"}, ruleArgs...)...); err != nil {
+		if !iptable.Exists(iptables.Nat, "POSTROUTING", ruleArgs...) {
+			if err := iptable.RawCombinedOutput(append([]string{"-t", "nat", "-I", "POSTROUTING"}, ruleArgs...)...); err != nil {
 				return fmt.Errorf("failed to add ingress localhost POSTROUTING rule for %s: %v", oifName, err)
 			}
 		}
 	}
 
 	for _, iPort := range ingressPorts {
-		if iptables.ExistChain(ingressChain, iptables.Nat) {
+		if iptable.ExistChain(ingressChain, iptables.Nat) {
 			rule := strings.Fields(fmt.Sprintf("-t nat %s %s -p %s --dport %d -j DNAT --to-destination %s:%d",
 				addDelOpt, ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort, gwIP, iPort.PublishedPort))
-			if err := iptables.RawCombinedOutput(rule...); err != nil {
+			if err := iptable.RawCombinedOutput(rule...); err != nil {
 				errStr := fmt.Sprintf("setting up rule failed, %v: %v", rule, err)
 				if !isDelete {
 					return fmt.Errorf("%s", errStr)
@@ -412,7 +414,7 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 		// 2) unmanaged containers on bridge networks
 		rule := strings.Fields(fmt.Sprintf("%s %s -m state -p %s --sport %d --state ESTABLISHED,RELATED -j ACCEPT",
 			addDelOpt, ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort))
-		if err := iptables.RawCombinedOutput(rule...); err != nil {
+		if err := iptable.RawCombinedOutput(rule...); err != nil {
 			errStr := fmt.Sprintf("setting up rule failed, %v: %v", rule, err)
 			if !isDelete {
 				return fmt.Errorf("%s", errStr)
@@ -422,7 +424,7 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 
 		rule = strings.Fields(fmt.Sprintf("%s %s -p %s --dport %d -j ACCEPT",
 			addDelOpt, ingressChain, strings.ToLower(PortConfig_Protocol_name[int32(iPort.Protocol)]), iPort.PublishedPort))
-		if err := iptables.RawCombinedOutput(rule...); err != nil {
+		if err := iptable.RawCombinedOutput(rule...); err != nil {
 			errStr := fmt.Sprintf("setting up rule failed, %v: %v", rule, err)
 			if !isDelete {
 				return fmt.Errorf("%s", errStr)
@@ -445,13 +447,14 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 // This chain has the rules to allow access to the published ports for swarm tasks
 // from local bridge networks and docker_gwbridge (ie:taks on other swarm netwroks)
 func arrangeIngressFilterRule() {
-	if iptables.ExistChain(ingressChain, iptables.Filter) {
-		if iptables.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
-			if err := iptables.RawCombinedOutput("-D", "FORWARD", "-j", ingressChain); err != nil {
+	iptable := iptables.GetIptable(iptables.IPv4)
+	if iptable.ExistChain(ingressChain, iptables.Filter) {
+		if iptable.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
+			if err := iptable.RawCombinedOutput("-D", "FORWARD", "-j", ingressChain); err != nil {
 				logrus.Warnf("failed to delete jump rule to ingressChain in filter table: %v", err)
 			}
 		}
-		if err := iptables.RawCombinedOutput("-I", "FORWARD", "-j", ingressChain); err != nil {
+		if err := iptable.RawCombinedOutput("-I", "FORWARD", "-j", ingressChain); err != nil {
 			logrus.Warnf("failed to add jump rule to ingressChain in filter table: %v", err)
 		}
 	}
@@ -590,6 +593,7 @@ func invokeFWMarker(path string, vip net.IP, fwMark uint32, ingressPorts []*Port
 
 // Firewall marker reexec function.
 func fwMarker() {
+	iptable := iptables.GetIptable(iptables.IPv4)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -643,7 +647,7 @@ func fwMarker() {
 		}
 
 		ruleParams := strings.Fields(fmt.Sprintf("-m ipvs --ipvs -d %s -j SNAT --to-source %s", subnet, eIP))
-		if !iptables.Exists("nat", "POSTROUTING", ruleParams...) {
+		if !iptable.Exists("nat", "POSTROUTING", ruleParams...) {
 			rule := append(strings.Fields("-t nat -A POSTROUTING"), ruleParams...)
 			rules = append(rules, rule)
 
@@ -662,7 +666,7 @@ func fwMarker() {
 	rules = append(rules, rule)
 
 	for _, rule := range rules {
-		if err := iptables.RawCombinedOutputNative(rule...); err != nil {
+		if err := iptable.RawCombinedOutputNative(rule...); err != nil {
 			logrus.Errorf("setting up rule failed, %v: %v", rule, err)
 			os.Exit(5)
 		}
@@ -697,6 +701,7 @@ func addRedirectRules(path string, eIP *net.IPNet, ingressPorts []*PortConfig) e
 
 // Redirecter reexec function.
 func redirecter() {
+	iptable := iptables.GetIptable(iptables.IPv4)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -749,7 +754,7 @@ func redirecter() {
 	}
 
 	for _, rule := range rules {
-		if err := iptables.RawCombinedOutputNative(rule...); err != nil {
+		if err := iptable.RawCombinedOutputNative(rule...); err != nil {
 			logrus.Errorf("setting up rule failed, %v: %v", rule, err)
 			os.Exit(6)
 		}
@@ -764,15 +769,15 @@ func redirecter() {
 		{"-d", eIP.String(), "-p", "udp", "-j", "DROP"},
 		{"-d", eIP.String(), "-p", "tcp", "-j", "DROP"},
 	} {
-		if !iptables.ExistsNative(iptables.Filter, "INPUT", rule...) {
-			if err := iptables.RawCombinedOutputNative(append([]string{"-A", "INPUT"}, rule...)...); err != nil {
+		if !iptable.ExistsNative(iptables.Filter, "INPUT", rule...) {
+			if err := iptable.RawCombinedOutputNative(append([]string{"-A", "INPUT"}, rule...)...); err != nil {
 				logrus.Errorf("setting up rule failed, %v: %v", rule, err)
 				os.Exit(7)
 			}
 		}
 		rule[0] = "-s"
-		if !iptables.ExistsNative(iptables.Filter, "OUTPUT", rule...) {
-			if err := iptables.RawCombinedOutputNative(append([]string{"-A", "OUTPUT"}, rule...)...); err != nil {
+		if !iptable.ExistsNative(iptables.Filter, "OUTPUT", rule...) {
+			if err := iptable.RawCombinedOutputNative(append([]string{"-A", "OUTPUT"}, rule...)...); err != nil {
 				logrus.Errorf("setting up rule failed, %v: %v", rule, err)
 				os.Exit(8)
 			}


### PR DESCRIPTION
This pull request addresses this open issue moby/moby#25407
Previously when IPv6 was enabled on Docker, ip6tables weren't manipulated to do Port Forwarding and IP masquerading. This PR addresses that in a way similar to the IPv4 implementation.

Relies on the following Moby PR to bring the EnableIPv6 flag through to libnetwork: moby/moby#35252

When combined with the Docker pull request, the fix can be verified after starting a container in bridge mode with port forwarding and IPv6 enabled:

Compare the iptables -t nat -L command with the ip6tables -t nat -L command
Compare iptables -t filter -L command with ip6tables -t filter -L command
Ping6 from within a running container to an outside device.

Note: This is the same as https://github.com/docker/libnetwork/pull/1992 but cleaner commits.