### PR TITLE
Prevent NPE in addServiceInfoToCluster()

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -583,7 +583,7 @@ func (ep *endpoint) deleteDriverInfoFromCluster() error {
 }
 
 func (ep *endpoint) addServiceInfoToCluster(sb *sandbox) error {
-	if ep.isAnonymous() && len(ep.myAliases) == 0 || ep.Iface().Address() == nil {
+	if ep.isAnonymous() && len(ep.myAliases) == 0 || ep.Iface() == nil || ep.Iface().Address() == nil {
 		return nil
 	}
 

--- a/endpoint_info.go
+++ b/endpoint_info.go
@@ -216,7 +216,7 @@ func (ep *endpoint) Iface() InterfaceInfo {
 		return ep.iface
 	}
 
-	return nil
+	return &endpointInterface{}
 }
 
 func (ep *endpoint) Interface() driverapi.InterfaceInfo {


### PR DESCRIPTION
`ep.Iface()` can return `nil`, in which case `Address()` would result in a NPE.

relates to https://github.com/moby/moby/issues/37506