### PR TITLE
Fix IPv6 address pool calculation

### DIFF
--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -115,7 +115,7 @@ func splitNetwork(size int, base *net.IPNet) []*net.IPNet {
 
 	for i := 0; i < n; i++ {
 		ip := copyIP(base.IP)
-		addIntToIP(ip, uint(i<<s))
+		addIntToIP(ip, uint(i), s)
 		list = append(list, &net.IPNet{IP: ip, Mask: mask})
 	}
 	return list
@@ -127,9 +127,14 @@ func copyIP(from net.IP) net.IP {
 	return ip
 }
 
-func addIntToIP(array net.IP, ordinal uint) {
-	for i := len(array) - 1; i >= 0; i-- {
-		array[i] |= (byte)(ordinal & 0xff)
-		ordinal >>= 8
+func addIntToIP(array net.IP, bits, shift uint) {
+	alignment := shift % 8
+	alignedBits := bits << alignment
+	alignedShift := shift - alignment
+
+	offset := uint(len(array))*8 - 8
+	for i := 0; i < len(array); i++ {
+		array[i] |= byte(alignedBits >> (offset - alignedShift))
+		offset -= 8
 	}
 }

--- a/ipamutils/utils_test.go
+++ b/ipamutils/utils_test.go
@@ -116,3 +116,22 @@ func TestInitAddressPools(t *testing.T) {
 	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[383].String(), "172.90.127.0/24"))
 	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[511].String(), "172.90.255.0/24"))
 }
+
+func TestInitAddressPoolsIPv6(t *testing.T) {
+	// Check high-bit byte-misaligned ranges and a common byte-aligned subnet length
+	err := ConfigLocalScopeDefaultNetworks([]*NetworkToSplit{
+		{"fc00::/7", 13},
+		{"2000:db8:0:100::/56", 64}})
+	assert.NilError(t, err)
+
+	// Check for Random IPAddresses in PredefinedLocalScopeDefaultNetworks  ex: first , last and middle
+	assert.Check(t, is.Len(PredefinedLocalScopeDefaultNetworks, 320), "Failed to find PredefinedLocalScopeDefaultNetworks")
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[0].String(), "fc00::/13"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[1].String(), "fc08::/13"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[16].String(), "fc80::/13"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[31].String(), "fcf8::/13"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[63].String(), "fdf8::/13"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[64].String(), "2000:db8:0:100::/64"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[168].String(), "2000:db8:0:168::/64"))
+	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[319].String(), "2000:db8:0:1ff::/64"))
+}


### PR DESCRIPTION
Address pool calculation doesn't current work when the subnet mask is less than 64 (or 96 on 32 bit architectures I think)

I tried to keep similar performance to the previous version of `addIntToIP` since I wasn't sure whether it mattered.