### PR TITLE
Use hcsshim osversion package for version checks, instead of docker/docker/pkg/system

### DIFF
--- a/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/drivers/windows/overlay/ov_endpoint_windows.go
@@ -155,7 +155,7 @@ func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo,
 
 	hnsEndpoint.Policies = append(hnsEndpoint.Policies, paPolicy)
 
-	if osversion.Build() > 16236 {
+	if osversion.Build() >= osversion.RS3 {
 		natPolicy, err := json.Marshal(hcsshim.PaPolicy{
 			Type: "OutBoundNAT",
 		})
@@ -285,11 +285,11 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 func endpointRequest(method, path, request string) (*hcsshim.HNSEndpoint, error) {
-	if windowsBuild == 14393 {
+	if windowsBuild < osversion.RS5 {
 		endpointMu.Lock()
 	}
 	hnsresponse, err := hcsshim.HNSEndpointRequest(method, path, request)
-	if windowsBuild == 14393 {
+	if windowsBuild < osversion.RS5 {
 		endpointMu.Unlock()
 	}
 	return hnsresponse, err

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -217,7 +217,7 @@ func (d *driver) parseNetworkOptions(id string, genericOptions map[string]string
 			}
 			config.VSID = uint(vsid)
 		case EnableOutboundNat:
-			if osversion.Build() <= 16236 {
+			if osversion.Build() < osversion.RS3 {
 				return nil, fmt.Errorf("Invalid network option. OutboundNat is not supported on this OS version")
 			}
 			b, err := strconv.ParseBool(value)

--- a/service_windows.go
+++ b/service_windows.go
@@ -27,7 +27,7 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	vip := lb.vip
 	ingressPorts := lb.service.ingressPorts
 
-	if osversion.Build() > 16236 {
+	if osversion.Build() >= osversion.RS3 {
 		lb.Lock()
 		defer lb.Unlock()
 		//find the load balancer IP for the network.
@@ -128,7 +128,7 @@ func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 		return
 	}
 
-	if osversion.Build() > 16236 {
+	if osversion.Build() >= osversion.RS3 {
 		if numEnabledBackends(lb) > 0 {
 			//Reprogram HNS (actually VFP) with the existing backends.
 			n.addLBBackend(ip, lb)


### PR DESCRIPTION
~This depends on https://github.com/docker/libnetwork/pull/2361, which brings in an up-to-date version of hcsshim.~

This replaces the use of docker/docker/pkg/system, in favour of the same code from Microsoft/hcsshim.

With this package, hard-coded build numbers are replaced with constants that are now defined in hcsshim.

Note that build 16236 is not defined in the package, and may be referring to RS2 (which was a client-only release).

Checks for that version were added in commits;

a9db5c53867a33c47c13a4eac7c1a28cc3c35054 (#1900), and 6681c0243cc03669a677efe4dde70976b1bf0746 (#2070)

In a9db5c53867a33c47c13a4eac7c1a28cc3c35054, it is described that the intent was to allow these options only in Windows RS3 so I changed the comparisons to match RS3 (and up) or disable the option on anything older than RS3.

