### PR TITLE
Revert "Always configure iptables forward policy"

### DIFF
--- a/drivers/bridge/setup_ip_forwarding.go
+++ b/drivers/bridge/setup_ip_forwarding.go
@@ -34,11 +34,11 @@ func setupIPForwarding(enableIPTables bool) error {
 		if err := configureIPForwarding(true); err != nil {
 			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
-	}
-
-	// Set the default policy on forward chain to drop only if the
-	// daemon option iptables is not set to false.
-	if enableIPTables {
+		// When enabling ip_forward set the default policy on forward chain to
+		// drop only if the daemon option iptables is not set to false.
+		if !enableIPTables {
+			return nil
+		}
 		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
 			if err := configureIPForwarding(false); err != nil {
 				logrus.Errorf("Disabling IP forwarding failed, %v", err)


### PR DESCRIPTION
Reverts docker/libnetwork#2450.

Fallout from changing the forwarding default policy to deny was greater than anticipated.