### PR TITLE
To address issue #2502 which I opened...

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -18,6 +18,14 @@ const (
 	IPv6
 )
 
+// constants for the method used to sord IP addresses
+const (
+	NONE = iota
+	ASCENDING
+	DESCENDING
+	RANDOM
+)
+
 // EncryptionKey is the libnetwork representation of the key distributed by the lead
 // manager.
 type EncryptionKey struct {


### PR DESCRIPTION
Added support for disabling the randomization of IP addresses in the response to DNS hostname lookup, as well as support for sorting the IP addresses in ascending or descending order.

Full backwards compatibility is maintained.

Performance penalty is 1 map lookup + 1 if statement with simple boolean equality check + 1 switch statement + sorting algorithm:
- NONE: constant
- ASCENDING: O(nlogn)
- DESCENDING: O(nlogn)
- RANDOM: O(n)

3 new functions are added to Resolver interface to support sort order:
- SetIPSortOrderDefault(int)
- SetIPSortOrderSpecific(string, int)
- ClearIPSortOrderSpecific(string)

3 new function implentations are added to support the interface:
- func (r *resolver) SetIPSortOrderDefault(ipSortMethod int)
- func (r *resolver) SetIPSortOrderSpecific(hostname string, ipSortMethod int)
- func (r *resolver) ClearIPSortOrderSpecific(hostname string)

1 new type is added to specify sort order:
- NONE
- ASCENDING
- DESCENDING
- RANDOM

Signed-off-by: Ian Morris Nieves <imnieves@gmail.com>