### PR TITLE
[19.03 backport] Dockerfile: update to Golang 1.12.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.12
+ARG GO_VERSION=1.12.17
 
 FROM golang:${GO_VERSION}-stretch as dev
 RUN apt-get update && apt-get -y install iptables \


### PR DESCRIPTION
backport of https://github.com/docker/libnetwork/pull/2513