### PR TITLE
Cleanup VFP during overlay network removal

### DIFF
--- a/network.go
+++ b/network.go
@@ -1088,6 +1088,10 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	// Cleanup the service discovery for this network
 	c.cleanupServiceDiscovery(n.ID())
 
+	// Cleanup the load balancer. On Windows this call is required
+	// to remove remote loadbalancers in VFP.
+	c.cleanupServiceBindings(n.ID())
+
 removeFromStore:
 	// deleteFromStore performs an atomic delete operation and the
 	// network.epCnt will help prevent any possible

--- a/service_common.go
+++ b/service_common.go
@@ -369,9 +369,11 @@ func (c *controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 	// sandboxes in the network only if the vip is valid.
 	if entries == 0 {
 		// The network may well have been deleted before the last
-		// of the service bindings.  That's ok, because removing
-		// the network sandbox implicitly removes the backend
-		// service bindings.
+		// of the service bindings.  That's ok on Linux because
+		// removing the network sandbox implicitly removes the
+		// backend service bindings.  Windows VFP cleanup requires
+		// calling cleanupServiceBindings on the network prior to
+		// deleting the network, performed by network.delete.
 		n, err := c.NetworkByID(nID)
 		if err == nil {
 			n.(*network).rmLBBackend(ip, lb, rmService, fullRemove)


### PR DESCRIPTION
Deleting a network sandbox on Linux implicitly clears OS (ipvs) load
balancer state.  Deleting an HNS network on Windows by contrast does not
inherently remove its corresponding VFP load balancers. The method to
remove load balancers belongs to the network and so must be called prior
to or while deleting a network. This commit reverts one line from
c47239d1e78950f9cc6fcab1d4e029e7df07082a, reintroducing a call to
explicitly remove backend load balancers during network removal.

Fixes #2527

Mirantis Ref: FIELD-2259