### PR TITLE
[19.03] Macvlan: Separate empty parent and internal

### DIFF
--- a/drivers/ipvlan/ipvlan_network.go
+++ b/drivers/ipvlan/ipvlan_network.go
@@ -57,8 +57,6 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	// if parent interface not specified, create a dummy type link to use named dummy+net_id
 	if config.Parent == "" {
 		config.Parent = getDummyName(stringid.TruncateID(config.ID))
-		// empty parent and --internal are handled the same. Set here to update k/v
-		config.Internal = true
 	}
 	foundExisting, err := d.createNetwork(config)
 	if err != nil {
@@ -95,19 +93,17 @@ func (d *driver) createNetwork(config *configuration) (bool, error) {
 		}
 	}
 	if !parentExists(config.Parent) {
-		// if the --internal flag is set, create a dummy link
-		if config.Internal {
-			err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
+		// Create a dummy link if a dummy name is set for parent
+		if dummyName := getDummyName(stringid.TruncateID(config.ID)); dummyName == config.Parent {
+			err := createDummyLink(config.Parent, dummyName)
 			if err != nil {
 				return false, err
 			}
 			config.CreatedSlaveLink = true
 
 			// notify the user in logs they have limited communications
-			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
-				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
-					config.Parent)
-			}
+			logrus.Debugf("Empty -o parent= flags limit communications to other containers inside of network: %s",
+				config.Parent)
 		} else {
 			// if the subinterface parent_iface.vlan_id checks do not pass, return err.
 			//  a valid example is 'eth0.10' for a parent iface 'eth0' with a vlan id '10'

--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -61,8 +61,6 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	// if parent interface not specified, create a dummy type link to use named dummy+net_id
 	if config.Parent == "" {
 		config.Parent = getDummyName(stringid.TruncateID(config.ID))
-		// empty parent and --internal are handled the same. Set here to update k/v
-		config.Internal = true
 	}
 	foundExisting, err := d.createNetwork(config)
 	if err != nil {
@@ -100,18 +98,16 @@ func (d *driver) createNetwork(config *configuration) (bool, error) {
 		}
 	}
 	if !parentExists(config.Parent) {
-		// if the --internal flag is set, create a dummy link
-		if config.Internal {
-			err := createDummyLink(config.Parent, getDummyName(stringid.TruncateID(config.ID)))
+		// Create a dummy link if a dummy name is set for parent
+		if dummyName := getDummyName(stringid.TruncateID(config.ID)); dummyName == config.Parent {
+			err := createDummyLink(config.Parent, dummyName)
 			if err != nil {
 				return false, err
 			}
 			config.CreatedSlaveLink = true
-			// notify the user in logs they have limited communications
-			if config.Parent == getDummyName(stringid.TruncateID(config.ID)) {
-				logrus.Debugf("Empty -o parent= and --internal flags limit communications to other containers inside of network: %s",
-					config.Parent)
-			}
+			// notify the user in logs that they have limited communications
+			logrus.Debugf("Empty -o parent= limit communications to other containers inside of network: %s",
+				config.Parent)
 		} else {
 			// if the subinterface parent_iface.vlan_id checks do not pass, return err.
 			//  a valid example is 'eth0.10' for a parent iface 'eth0' with a vlan id '10'


### PR DESCRIPTION
https://github.com/docker/libnetwork/pull/2419 and
https://github.com/docker/libnetwork/pull/2407
attempted to seperate out empty parent and internal for
macvlan and ipvlan networks

However it didnt pass the integration tests in moby
https://github.com/moby/moby/pull/40596 and exposed some
more plumbing that needed to be done to make sure
we separate the two things

If the -o parent is empty we create a dummylink
and if internal is set we dont add a default gateway
and make sure north-south communication cannot take place
(only east-west / container-container can)

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>