### PR TITLE
Fixes moby/moby#40388, produce an error with invalid address pool

### DIFF
--- a/ipams/builtin/builtin_unix.go
+++ b/ipams/builtin/builtin_unix.go
@@ -35,7 +35,10 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 		}
 	}
 
-	ipamutils.ConfigLocalScopeDefaultNetworks(GetDefaultIPAddressPool())
+	err := ipamutils.ConfigLocalScopeDefaultNetworks(GetDefaultIPAddressPool())
+	if err != nil {
+		return err
+	}
 
 	a, err := ipam.NewAllocator(localDs, globalDs)
 	if err != nil {


### PR DESCRIPTION
**- What I did**
from moby/moby#40388
> Things to fix;
> - if `base=10.123.0.0` is invalid, it should produce an error
> - if the given configuration file does not contain `default-address-pools`, it should not reset the value set on the command-line

_Originally posted by @thaJeztah in https://github.com/moby/moby/issues/40388#issuecomment-576238514_

This PR will produce an error if given an invalid address pool like `base=10.123.0.0,size=24`  (missing `/16`)

**- How I did it**
if the default address pool is invalid, `ConfigLocalScopeDefaultNetworks` will return an error, so just return the error rather than omit it and it's quite safe. 

The output likes: 
```
Mar 17 00:10:29 master dockerd[12069]: failed to start daemon: Error initializing network controller: error obtaining controller instance: invalid base pool "10.123.0.0": invalid CIDR address: 10.123.0.0
```




