### PR TITLE
[19.03 backport] Fix NPE due to null value returned by ep.Iface()

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -596,7 +596,7 @@ func (ep *endpoint) deleteDriverInfoFromCluster() error {
 }
 
 func (ep *endpoint) addServiceInfoToCluster(sb *sandbox) error {
-	if ep.isAnonymous() && len(ep.myAliases) == 0 || ep.Iface().Address() == nil {
+	if ep.isAnonymous() && len(ep.myAliases) == 0 || ep.Iface() == nil || ep.Iface().Address() == nil {
 		return nil
 	}
 
@@ -719,7 +719,7 @@ func (ep *endpoint) deleteServiceInfoFromCluster(sb *sandbox, fullRemove bool, m
 		}
 	}
 
-	if ep.Iface().Address() != nil {
+	if ep.Iface() != nil && ep.Iface().Address() != nil {
 		if ep.svcID != "" {
 			// This is a task part of a service
 			var ingressPorts []*PortConfig

--- a/controller.go
+++ b/controller.go
@@ -979,6 +979,10 @@ func (c *controller) reservePools() {
 			continue
 		}
 		for _, ep := range epl {
+			if ep.Iface() == nil {
+				logrus.Warnf("endpoint interface is empty for %q (%s)", ep.Name(), ep.ID())
+				continue
+			}
 			if err := ep.assignAddress(ipam, true, ep.Iface().AddressIPv6() != nil); err != nil {
 				logrus.Warnf("Failed to reserve current address for endpoint %q (%s) on network %q (%s)",
 					ep.Name(), ep.ID(), n.Name(), n.ID())

--- a/network.go
+++ b/network.go
@@ -1329,7 +1329,7 @@ func (n *network) EndpointByID(id string) (Endpoint, error) {
 func (n *network) updateSvcRecord(ep *endpoint, localEps []*endpoint, isAdd bool) {
 	var ipv6 net.IP
 	epName := ep.Name()
-	if iface := ep.Iface(); iface.Address() != nil {
+	if iface := ep.Iface(); iface != nil && iface.Address() != nil {
 		myAliases := ep.MyAliases()
 		if iface.AddressIPv6() != nil {
 			ipv6 = iface.AddressIPv6().IP


### PR DESCRIPTION
backport of https://github.com/moby/libnetwork/pull/2544
addresses https://github.com/moby/moby/issues/37506

This PR carryforwards https://github.com/moby/libnetwork/pull/2239
and incorporates the suggestions in comments to fix the NPE and
potential NPEs due to a null value returned by ep.Iface()
