### PR TITLE
vendor: update moby/ipvs v1.0.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -58,4 +58,4 @@ go.opencensus.io                        9c377598961b706d1542bd2d84d538b5094d596e
 gotest.tools                            1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 github.com/google/go-cmp                3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
 
-github.com/moby/ipvs                    8f137da6850a975020f4f739c589d293dd3a9d7b # v1.0.0
+github.com/moby/ipvs                    4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1


### PR DESCRIPTION
full diff: https://github.com/moby/ipvs/compare/v1.0.0...v1.0.1

- Fix compatibility issue on older kernels (< 3.18) where the address
  family attribute for destination servers do not exist
- Fix the stats attribute check when parsing destination addresses
- NetlinkSocketsTimeout should be a constant

