### PR TITLE
reduce parameters for func JoinOptionPriority

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1055,7 +1055,7 @@ func CreateOptionLoadBalancer() EndpointOption {
 
 // JoinOptionPriority function returns an option setter for priority option to
 // be passed to the endpoint.Join() method.
-func JoinOptionPriority(ep Endpoint, prio int) EndpointOption {
+func JoinOptionPriority(prio int) EndpointOption {
 	return func(ep *endpoint) {
 		// ep lock already acquired
 		c := ep.network.getController()

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -51,7 +51,7 @@ fe90::2	somehost.example.com somehost
 		t.Fatal(err)
 	}
 
-	if err := ep1.Join(sbx, JoinOptionPriority(ep1, 1)); err != nil {
+	if err := ep1.Join(sbx, JoinOptionPriority(1)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -110,15 +110,15 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ep1.Join(sbx, JoinOptionPriority(ep1, 1)); err != nil {
+	if err := ep1.Join(sbx, JoinOptionPriority(1)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep2.Join(sbx, JoinOptionPriority(ep2, 2)); err != nil {
+	if err := ep2.Join(sbx, JoinOptionPriority(2)); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ep3.Join(sbx, JoinOptionPriority(ep3, 3)); err != nil {
+	if err := ep3.Join(sbx, JoinOptionPriority(3)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,7 +145,7 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	}
 
 	// Re-add ep3 back
-	if err := ep3.Join(sbx, JoinOptionPriority(ep3, 3)); err != nil {
+	if err := ep3.Join(sbx, JoinOptionPriority(3)); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
```
func JoinOptionPriority(ep Endpoint, prio int) EndpointOption {
	return func(ep *endpoint) {
		// ep lock already acquired
		c := ep.network.getController()
		c.Lock()
		sb, ok := c.sandboxes[ep.sandboxID]
		c.Unlock()
		if !ok {
			logrus.Errorf("Could not set endpoint priority value during Join to endpoint %s: No sandbox id present in endpoint", ep.id)
			return
		}
		sb.epPriority[ep.id] = prio
	}
}
```

maybe we don't need this parameters `ep Endpoint` ? I made some changes for this.

Relevant PRs:
[moby/moby#40974](https://github.com/moby/moby/pull/40974) (open)
[docker/cli#2529](https://github.com/docker/cli/pull/2529)(open)

Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>