### PR TITLE
Fix 'failed to get network during CreateEndpoint'

### DIFF
--- a/network.go
+++ b/network.go
@@ -1181,7 +1181,8 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	ep.locator = n.getController().clusterHostID()
 	ep.network, err = ep.getNetworkFromStore()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network during CreateEndpoint: %v", err)
+		logrus.Errorf("failed to get network during CreateEndpoint: %v", err)
+		return nil, err
 	}
 	n = ep.network
 

--- a/store.go
+++ b/store.go
@@ -85,7 +85,7 @@ func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 			return n, nil
 		}
 	}
-	return nil, fmt.Errorf("network %s not found", nid)
+	return nil, ErrNoSuchNetwork(nid)
 }
 
 func (c *controller) getNetworksForScope(scope string) ([]*network, error) {


### PR DESCRIPTION
Fixes https://github.com/docker/for-linux/issues/888

Fix 'failed to get network during CreateEndpoint' during container starting.
Change the error type to `libnetwork.ErrNoSuchNetwork`, so `Start()` in docker engine `daemon/cluster/executor/container/controller.go` will recreate the network.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>