### PR TITLE
store.getNetworksFromStore() remove unused error return

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -1020,12 +1020,7 @@ func (c *controller) addNetwork(n *network) error {
 func (c *controller) Networks() []Network {
 	var list []Network
 
-	networks, err := c.getNetworksFromStore()
-	if err != nil {
-		logrus.Error(err)
-	}
-
-	for _, n := range networks {
+	for _, n := range c.getNetworksFromStore() {
 		if n.inDelete {
 			continue
 		}

--- a/store.go
+++ b/store.go
@@ -80,11 +80,7 @@ func (c *controller) getStores() []datastore.DataStore {
 }
 
 func (c *controller) getNetworkFromStore(nid string) (*network, error) {
-	ns, err := c.getNetworksFromStore()
-	if err != nil {
-		return nil, err
-	}
-	for _, n := range ns {
+	for _, n := range c.getNetworksFromStore() {
 		if n.id == nid {
 			return n, nil
 		}
@@ -128,12 +124,11 @@ func (c *controller) getNetworksForScope(scope string) ([]*network, error) {
 	return nl, nil
 }
 
-func (c *controller) getNetworksFromStore() ([]*network, error) {
+func (c *controller) getNetworksFromStore() []*network {
 	var nl []*network
 
 	for _, store := range c.getStores() {
-		kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix),
-			&network{ctrlr: c})
+		kvol, err := store.List(datastore.Key(datastore.NetworkKeyPrefix), &network{ctrlr: c})
 		// Continue searching in the next store if no keys found in this store
 		if err != nil {
 			if err != datastore.ErrKeyNotFound {
@@ -143,10 +138,8 @@ func (c *controller) getNetworksFromStore() ([]*network, error) {
 		}
 
 		kvep, err := store.Map(datastore.Key(epCntKeyPrefix), &endpointCnt{})
-		if err != nil {
-			if err != datastore.ErrKeyNotFound {
-				logrus.Warnf("failed to get endpoint_count map for scope %s: %v", store.Scope(), err)
-			}
+		if err != nil && err != datastore.ErrKeyNotFound {
+			logrus.Warnf("failed to get endpoint_count map for scope %s: %v", store.Scope(), err)
 		}
 
 		for _, kvo := range kvol {
@@ -168,7 +161,7 @@ func (c *controller) getNetworksFromStore() ([]*network, error) {
 		}
 	}
 
-	return nl, nil
+	return nl
 }
 
 func (n *network) getEndpointFromStore(eid string) (*endpoint, error) {
@@ -455,13 +448,7 @@ func (c *controller) startWatch() {
 }
 
 func (c *controller) networkCleanup() {
-	networks, err := c.getNetworksFromStore()
-	if err != nil {
-		logrus.Warnf("Could not retrieve networks from store(s) during network cleanup: %v", err)
-		return
-	}
-
-	for _, n := range networks {
+	for _, n := range c.getNetworksFromStore() {
 		if n.inDelete {
 			logrus.Infof("Removing stale network %s (%s)", n.Name(), n.ID())
 			if err := n.delete(true, true); err != nil {


### PR DESCRIPTION
noticed this while reviewing https://github.com/moby/libnetwork/pull/2554, so thought I'd open as a pull request

This function always returned `nil`, so we can remove the error return, and update other functions that were handling errors.
