### PR TITLE
[master] bridge: disable IPv6 router advertisements

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -689,6 +689,12 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	bridgeAlreadyExists := bridgeIface.exists()
 	if !bridgeAlreadyExists {
 		bridgeSetup.queueStep(setupDevice)
+		bridgeSetup.queueStep(setupDefaultSysctl)
+	}
+
+	// For the default bridge, set expected sysctls
+	if config.DefaultBridge {
+		bridgeSetup.queueStep(setupDefaultSysctl)
 	}
 
 	// Even if a bridge exists try to setup IPv4.

--- a/drivers/bridge/setup_device.go
+++ b/drivers/bridge/setup_device.go
@@ -2,6 +2,9 @@ package bridge
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/libnetwork/netutils"
@@ -47,6 +50,22 @@ func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 	}
 
 	return err
+}
+
+func setupDefaultSysctl(config *networkConfiguration, i *bridgeInterface) error {
+	// Disable IPv6 router advertisements originating on the bridge
+	sysPath := filepath.Join("/proc/sys/net/ipv6/conf/", config.BridgeName, "accept_ra")
+	if _, err := os.Stat(sysPath); err != nil {
+		logrus.
+			WithField("bridge", config.BridgeName).
+			WithField("syspath", sysPath).
+			Info("failed to read ipv6 net.ipv6.conf.<bridge>.accept_ra")
+		return nil
+	}
+	if err := ioutil.WriteFile(sysPath, []byte{'0', '\n'}, 0644); err != nil {
+		return fmt.Errorf("libnetwork: Unable to disable IPv6 router advertisement: %v", err)
+	}
+	return nil
 }
 
 // SetupDeviceUp ups the given bridge interface.


### PR DESCRIPTION
forward-porting https://github.com/moby/libnetwork/commit/153d0769a1181bf591a9637fd487a541ec7db1e6 from bump_19.03 to master


related: https://github.com/kubernetes/kubernetes/issues/91507

quoting https://github.com/docker/docker.github.io/pull/10940#issuecomment-637437540

> In the Docker default configuration the container network interface is a virtual ethernet link going to the host (veth interface).
> In this configuration, an attacker able to run a process as root in a container can send and receive arbitrary packets to the host using the CAP_NET_RAW capability (present in the default configuration).
> 
> If IPv6 is not totally disabled on the host (via ipv6.disable=1 on the kernel cmdline), it will be either unconfigured or configured on some interfaces, but it’s pretty likely that ipv6 forwarding is disabled, ie /proc/sys/net/ipv6/conf/*/forwarding == 0.
> Also by default, /proc/sys/net/ipv6/conf/*/accept_ra == 1. The combination of these 2 sysctls means that the host accepts router advertisements and configures the IPv6 stack using them.
> 
> By sending “rogue” router advertisements from a container, an attacker can reconfigure the host to redirect part or all of the IPv6 traffic of the host to the attacker controlled container.
> Even if there was no IPv6 traffic before, if the DNS returns A (IPv4) and AAAA (IPv6) records, many HTTP libraries will try to connect via IPv6 first then fallback to IPv4, giving an opportunity to the attacker to respond.
> If by chance the host has a vulnerability like last year’s RCE in apt (CVE-2019-3462), the attacker can now escalate to the host.
> 
> As CAP_NET_ADMIN is not present by default for Docker containers, the attacker can’t configure the IPs they want to MitM, they can’t use iptables to NAT or REDIRECT the traffic, and they can’t use IP_TRANSPARENT.
> The attacker can however still use CAP_NET_RAW and implement a tcp/ip stack in user space.