### PR TITLE
client/mflag: remove use of docker/docker/pkg/homedir

### DIFF
--- a/client/mflag/flag.go
+++ b/client/mflag/flag.go
@@ -91,8 +91,6 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
-
-	"github.com/docker/docker/pkg/homedir"
 )
 
 // ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
@@ -538,7 +536,7 @@ func isZeroValue(value string) bool {
 // otherwise, the default values of all defined flags in the set.
 func (fs *FlagSet) PrintDefaults() {
 	writer := tabwriter.NewWriter(fs.Out(), 20, 1, 3, ' ', 0)
-	home := homedir.Get()
+	home, _ := os.UserHomeDir()
 
 	// Don't substitute when HOME is /
 	if runtime.GOOS != "windows" && home == "/" {
@@ -561,7 +559,7 @@ func (fs *FlagSet) PrintDefaults() {
 			val := flag.DefValue
 
 			if home != "" && strings.HasPrefix(val, home) {
-				val = homedir.GetShortcutString() + val[len(home):]
+				val = getShortcutString() + val[len(home):]
 			}
 
 			if isZeroValue(val) {
@@ -577,6 +575,13 @@ func (fs *FlagSet) PrintDefaults() {
 		}
 	})
 	writer.Flush()
+}
+
+func getShortcutString() string {
+	if runtime.GOOS == "windows" {
+		return "%USERPROFILE%"
+	}
+	return "~"
 }
 
 // PrintDefaults prints to standard error the default values of all defined command-line flags.


### PR DESCRIPTION
relates to https://github.com/moby/libnetwork/pull/2559#discussion_r434545503

The homedir package was only used to print default values for flags that contained paths inside the user's home-directory in a slightly nicer way (replace `/users/home` with `~`).

Given that this is not critical, we can replace this with golang's function, which does not depend on libcontainer.

There's still one use of the homedir package in docker/docker/opts, which is used by the dnet binary (but only requires the homedir package when running in rootless mode);

https://github.com/moby/libnetwork/blob/13a4da01ec396d4bd59cc2108a7d183d7ac7fddd/cmd/dnet/dnet.go#L418-L419

calls out to `opts.ParseHost()`, which uses `homedir.GetRuntimeDir()`

https://github.com/moby/libnetwork/blob/7f60f05552dd6f88aa0a36640186fe155c471b82/vendor/github.com/docker/docker/opts/hosts.go#L54-L58

Perhaps we can work around that; will have to look into that.