### PR TITLE
log error instead if disabling IPv6 router advertisement failed

### DIFF
--- a/drivers/bridge/setup_device.go
+++ b/drivers/bridge/setup_device.go
@@ -63,7 +63,7 @@ func setupDefaultSysctl(config *networkConfiguration, i *bridgeInterface) error 
 		return nil
 	}
 	if err := ioutil.WriteFile(sysPath, []byte{'0', '\n'}, 0644); err != nil {
-		return fmt.Errorf("libnetwork: Unable to disable IPv6 router advertisement: %v", err)
+		logrus.WithError(err).Warn("unable to disable IPv6 router advertisement")
 	}
 	return nil
 }


### PR DESCRIPTION
addresses https://github.com/docker/for-linux/issues/1033

Previously, failing to disable IPv6 router advertisement prevented the daemon to start.

An issue was reported by a user that started docker using `systemd-nspawn "machine"`,
which produced an error;

    failed to start daemon: Error initializing network controller:
    Error creating default "bridge" network: libnetwork:
    Unable to disable IPv6 router advertisement:
    open /proc/sys/net/ipv6/conf/docker0/accept_ra: read-only file system

This patch changes the error to a log-message instead.
