### PR TITLE
[19.03 backport] Fix 'failed to get network during CreateEndpoint'

### DIFF
--- a/network.go
+++ b/network.go
@@ -1181,7 +1181,8 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	ep.locator = n.getController().clusterHostID()
 	ep.network, err = ep.getNetworkFromStore()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network during CreateEndpoint: %v", err)
+		logrus.Errorf("failed to get network during CreateEndpoint: %v", err)
+		return nil, err
 	}
 	n = ep.network
 

--- a/store.go
+++ b/store.go
@@ -103,8 +103,7 @@ func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 		}
 		return n, nil
 	}
-
-	return nil, fmt.Errorf("network %s not found", nid)
+	return nil, ErrNoSuchNetwork(nid)
 }
 
 func (c *controller) getNetworksForScope(scope string) ([]*network, error) {


### PR DESCRIPTION
Fix 'failed to get network during CreateEndpoint' during container starting.
Change the error type to `libnetwork.ErrNoSuchNetwork`, so `Start()` in `daemon/cluster/executor/container/controller.go` will recreate the network.

Signed-off-by: Xinfeng Liu <xinfeng.liu@gmail.com>
(cherry picked from commit 1df7f7e6d1e809362b16aba8893675ef81b1b9ab)
Signed-off-by: Shane Jarych <sjarych@mirantis.com>