### PR TITLE
[18.09 backport] Fix 'failed to get network during CreateEndpoint

### DIFF
--- a/network.go
+++ b/network.go
@@ -1181,7 +1181,8 @@ func (n *network) createEndpoint(name string, options ...EndpointOption) (Endpoi
 	ep.locator = n.getController().clusterHostID()
 	ep.network, err = ep.getNetworkFromStore()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network during CreateEndpoint: %v", err)
+		logrus.Errorf("failed to get network during CreateEndpoint: %v", err)
+		return nil, err
 	}
 	n = ep.network
 

--- a/store.go
+++ b/store.go
@@ -103,8 +103,7 @@ func (c *controller) getNetworkFromStore(nid string) (*network, error) {
 		}
 		return n, nil
 	}
-
-	return nil, fmt.Errorf("network %s not found", nid)
+	return nil, ErrNoSuchNetwork(nid)
 }
 
 func (c *controller) getNetworksForScope(scope string) ([]*network, error) {


### PR DESCRIPTION
This is a backport of https://github.com/moby/libnetwork/pull/2554 that I'm hoping we can merge into the bump_18.09 branch. Thanks!