### PR TITLE
Skip redundant kernel version checks

### DIFF
--- a/drivers/bridge/netlink_deprecated_linux.go
+++ b/drivers/bridge/netlink_deprecated_linux.go
@@ -7,8 +7,6 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
-
-	"github.com/docker/libnetwork/netutils"
 )
 
 const (
@@ -106,7 +104,7 @@ func ioctlSetMacAddress(name, addr string) error {
 	return nil
 }
 
-func ioctlCreateBridge(name string, setMacAddr bool) error {
+func ioctlCreateBridge(name, macAddr string) error {
 	if len(name) >= ifNameSize {
 		return fmt.Errorf("Interface name %s too long", name)
 	}
@@ -124,8 +122,5 @@ func ioctlCreateBridge(name string, setMacAddr bool) error {
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(s), ioctlBrAdd, uintptr(unsafe.Pointer(nameBytePtr))); err != 0 {
 		return err
 	}
-	if setMacAddr {
-		return ioctlSetMacAddress(name, netutils.GenerateRandomMAC().String())
-	}
-	return nil
+	return ioctlSetMacAddress(name, macAddr)
 }

--- a/drivers/macvlan/macvlan_network.go
+++ b/drivers/macvlan/macvlan_network.go
@@ -3,7 +3,6 @@ package macvlan
 import (
 	"fmt"
 
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
@@ -17,15 +16,7 @@ import (
 // CreateNetwork the network for the specified driver type
 func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	defer osl.InitOSContext()()
-	kv, err := kernel.GetKernelVersion()
-	if err != nil {
-		return fmt.Errorf("failed to check kernel version for %s driver support: %v", macvlanType, err)
-	}
-	// ensure Kernel version is >= v3.9 for macvlan support
-	if kv.Kernel < macvlanKernelVer || (kv.Kernel == macvlanKernelVer && kv.Major < macvlanMajorVer) {
-		return fmt.Errorf("kernel version failed to meet the minimum macvlan kernel requirement of %d.%d, found %d.%d.%d",
-			macvlanKernelVer, macvlanMajorVer, kv.Kernel, kv.Major, kv.Minor)
-	}
+
 	// reject a null v4 network
 	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
 		return fmt.Errorf("ipv4 pool is empty")

--- a/drivers/macvlan/macvlan_setup.go
+++ b/drivers/macvlan/macvlan_setup.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	dummyPrefix      = "dm-" // macvlan prefix for dummy parent interface
-	macvlanKernelVer = 3     // minimum macvlan kernel support
-	macvlanMajorVer  = 9     // minimum macvlan major kernel support
+	dummyPrefix = "dm-" // macvlan prefix for dummy parent interface
 )
 
 // Create the macvlan slave specifying the source name


### PR DESCRIPTION
All distros that are supported by Docker now have at least kernel version 3.10, so these checks should no longer be needed.