### PR TITLE
ensure docker-proxy sends UDP responses from correct source IP

### DIFF
--- a/cmd/proxy/network_proxy_test.go
+++ b/cmd/proxy/network_proxy_test.go
@@ -243,8 +243,10 @@ func TestUDP4SrcAddrProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testAddr := strings.ReplaceAll(proxy.FrontendAddr().String(), "0.0.0.0", "127.0.0.2")
-	testProxyAt(t, "udp", proxy, testAddr, false)
+	// Connect to loopback but on 127.0.0.2 to test if srcaddr set correctly
+	testAddr := proxy.FrontendAddr().(*net.UDPAddr)
+	testAddr.IP = net.IPv4(127, 0, 0, 2)
+	testProxyAt(t, "udp", proxy, testAddr.String(), false)
 }
 
 func TestUDP6Proxy(t *testing.T) {

--- a/cmd/proxy/network_proxy_test.go
+++ b/cmd/proxy/network_proxy_test.go
@@ -234,6 +234,19 @@ func TestUDP4Proxy(t *testing.T) {
 	testProxy(t, "udp", proxy, false)
 }
 
+func TestUDP4SrcAddrProxy(t *testing.T) {
+	backend := NewEchoServer(t, "udp", "127.0.0.1:0", EchoServerOptions{})
+	defer backend.Close()
+	backend.Run()
+	frontendAddr := &net.UDPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 0}
+	proxy, err := NewProxy(frontendAddr, backend.LocalAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testAddr := strings.ReplaceAll(proxy.FrontendAddr().String(), "0.0.0.0", "127.0.0.2")
+	testProxyAt(t, "udp", proxy, testAddr, false)
+}
+
 func TestUDP6Proxy(t *testing.T) {
 	t.Skip("Need to start CI docker with --ipv6")
 	backend := NewEchoServer(t, "udp", "[::1]:0", EchoServerOptions{})

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -13,9 +13,9 @@ type ipVersion string
 
 const (
 	// IPv4 is version 4
-	ipv4 ipVersion = "4"
+	ipVer4 ipVersion = "4"
 	// IPv4 is version 6
-	ipv6 ipVersion = "6"
+	ipVer6 ipVersion = "6"
 )
 
 // Proxy defines the behavior of a proxy. It forwards traffic back and forth

--- a/cmd/proxy/sctp_proxy.go
+++ b/cmd/proxy/sctp_proxy.go
@@ -20,9 +20,9 @@ type SCTPProxy struct {
 // NewSCTPProxy creates a new SCTPProxy.
 func NewSCTPProxy(frontendAddr, backendAddr *sctp.SCTPAddr) (*SCTPProxy, error) {
 	// detect version of hostIP to bind only to correct version
-	ipVersion := ipv4
+	ipVersion := ipVer4
 	if frontendAddr.IPAddrs[0].IP.To4() == nil {
-		ipVersion = ipv6
+		ipVersion = ipVer6
 	}
 	listener, err := sctp.ListenSCTP("sctp"+string(ipVersion), frontendAddr)
 	if err != nil {

--- a/cmd/proxy/tcp_proxy.go
+++ b/cmd/proxy/tcp_proxy.go
@@ -18,9 +18,9 @@ type TCPProxy struct {
 // NewTCPProxy creates a new TCPProxy.
 func NewTCPProxy(frontendAddr, backendAddr *net.TCPAddr) (*TCPProxy, error) {
 	// detect version of hostIP to bind only to correct version
-	ipVersion := ipv4
+	ipVersion := ipVer4
 	if frontendAddr.IP.To4() == nil {
-		ipVersion = ipv6
+		ipVersion = ipVer6
 	}
 	listener, err := net.ListenTCP("tcp"+string(ipVersion), frontendAddr)
 	if err != nil {

--- a/cmd/proxy/udp_proxy.go
+++ b/cmd/proxy/udp_proxy.go
@@ -110,7 +110,6 @@ func (proxy *UDPProxy) replyLoop(proxyConn *net.UDPConn, clientAddr *net.UDPAddr
 	var oobBuf []byte
 
 	if srcAddr != nil {
-
 		if srcAddr.To4() != nil {
 			cm := new(ipv4.ControlMessage)
 			cm.Src = *srcAddr
@@ -192,7 +191,7 @@ func (proxy *UDPProxy) Run() {
 		// the appropriate src IP automatically
 		var to *net.IP = nil
 
-		if from.IP.To16() != nil {
+		if from.IP.To4() == nil {
 			cm := new(ipv6.ControlMessage)
 			err = cm.Parse(oobBuf)
 

--- a/cmd/proxy/udp_proxy.go
+++ b/cmd/proxy/udp_proxy.go
@@ -60,9 +60,9 @@ type UDPProxy struct {
 // NewUDPProxy creates a new UDPProxy.
 func NewUDPProxy(frontendAddr, backendAddr *net.UDPAddr) (*UDPProxy, error) {
 	// detect version of hostIP to bind only to correct version
-	ipVersion := ipv4
+	ipVersion := ipVer4
 	if frontendAddr.IP.To4() == nil {
-		ipVersion = ipv6
+		ipVersion = ipVer6
 	}
 	listener, err := net.ListenUDP("udp"+string(ipVersion), frontendAddr)
 	if err != nil {


### PR DESCRIPTION
When docker-proxy listens for UDP connections on `0.0.0.0` or `::` it is not garuanteed to respond to a packet from the same IP the packet was sent to. This affects machines running docker-proxy that are multi-homed (multiple default gateways), or have multiple IPs assigned to the same interface. The impact is that packets may not be routed correctly back to the client due to the change of source-ip.

Currently the only workaround is to explicitly bind docker-proxy to each local IP address (e.g. `-p 1.1.1.1:1234/1234, -p 1.1.1.2:1234/1234`), which is not possible in situations where IPs change (for instance, VPN tunnels coming up and down).

This PR uses the `IP_PKTINFO` socket option to retrieve the destination IP of the packet received by the host side, and ensures responses for the given connection are sent from the same IP. This should close https://github.com/moby/libnetwork/issues/1729

I've added a basic unit test which simulate a multi-homed host, specifically:
  * EchoServer binds to `127.0.0.1`
  * Proxy binds to `0.0.0.0` on the host side, so it will accept connections to any IP assigned to the host
  * A test connection to `127.0.0.2` (simulating a connection to a secondary IP address on a host) is initiated

Prior to this patch, docker-proxy would accept the packet on the 127.0.0.2 address, but respond from the 127.0.0.1 address. After the patch docker-proxy responds from the same IP the initial packet was sent to.

This is my first contribution to libnetwork/moby/docker, and I'm not a Go developer, so I appreciate any feedback or changes that may be required, and am happy to discuss/further advocate for this change.
