### PR TITLE
CircleCI: update to Docker 19.03.12, and enable BuildKit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: stable
+          version: 19.03.12
           reusable: true
           exclusive: false
       - run: make builder
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: stable
+          version: 19.03.12
           reusable: true
           exclusive: false
       - run: make build
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: stable
+          version: 19.03.12
           reusable: true
           exclusive: false
       - run: make check
@@ -45,7 +45,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: stable
+          version: 19.03.12
           reusable: true
           exclusive: false
       - run: make cross
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: stable
+          version: 19.03.12
           reusable: true
           exclusive: false
       - run: make unit-tests

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all-local: build-local check-local clean
 # builder builds the libnetworkbuild container.  All wrapper targets
 # must depend on this to ensure that the container exists.
 builder:
-	docker build -t ${build_image} --build-arg=GO_VERSION ${dockerbuildargs}
+	DOCKER_BUILDKIT=1 docker build --progress=plain  -t ${build_image} --build-arg=GO_VERSION ${dockerbuildargs}
 
 build: builder
 	@echo "🐳 $@"
@@ -53,10 +53,10 @@ build-local:
 build-images:
 	@echo "🐳 $@"
 	cp cmd/diagnostic/daemon.json ./bin
-	docker build -f cmd/diagnostic/Dockerfile.client -t dockereng/network-diagnostic:onlyclient bin/
-	docker build -f cmd/diagnostic/Dockerfile.dind -t dockereng/network-diagnostic:17.12-dind bin/
-	docker build -f cmd/networkdb-test/Dockerfile -t dockereng/e2e-networkdb:master bin/
-	docker build -t dockereng/network-diagnostic:support.sh support/
+	DOCKER_BUILDKIT=1 docker build --progress=plain  -f cmd/diagnostic/Dockerfile.client -t dockereng/network-diagnostic:onlyclient bin/
+	DOCKER_BUILDKIT=1 docker build --progress=plain  -f cmd/diagnostic/Dockerfile.dind -t dockereng/network-diagnostic:17.12-dind bin/
+	DOCKER_BUILDKIT=1 docker build --progress=plain  -f cmd/networkdb-test/Dockerfile -t dockereng/e2e-networkdb:master bin/
+	DOCKER_BUILDKIT=1 docker build --progress=plain  -t dockereng/network-diagnostic:support.sh support/
 
 push-images: build-images
 	@echo "🐳 $@"


### PR DESCRIPTION
The "stable" option gave Docker 17.09, which is pretty old