### PR TITLE
service_linux: Fix null dereference in findLBEndpointSandbox

### DIFF
--- a/service_linux.go
+++ b/service_linux.go
@@ -67,11 +67,12 @@ func (n *network) findLBEndpointSandbox() (*endpoint, *sandbox, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("Unable to get sandbox for %s(%s) in for %s", ep.Name(), ep.ID(), n.ID())
 	}
-	ep = sb.getEndpoint(ep.ID())
-	if ep == nil {
+	var sep *endpoint
+	sep = sb.getEndpoint(ep.ID())
+	if sep == nil {
 		return nil, nil, fmt.Errorf("Load balancing endpoint %s(%s) removed from %s", ep.Name(), ep.ID(), n.ID())
 	}
-	return ep, sb, nil
+	return sep, sb, nil
 }
 
 // Searches the OS sandbox for the name of the endpoint interface


### PR DESCRIPTION
In findLBEndpointSandbox, there are a number of checks which can return an error message. The final check will cause the program to crash if the sandbox doesn't return an endpoint, as the error message calls methods on the null pointer. This patch fixes this to use the previous (valid) pointer to get information for the error message.