### PR TITLE
portallocator: various cleanups, remove init()

### DIFF
--- a/portallocator/portallocator.go
+++ b/portallocator/portallocator.go
@@ -110,6 +110,7 @@ func getDefaultPortRange() (int, int) {
 		start, end, err = sanitizePortRange(start, end)
 	}
 	if err != nil {
+		logrus.WithError(err).Infof("falling back to default port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 		start, end = defaultPortRangeStart, defaultPortRangeEnd
 	}
 	return start, end

--- a/portallocator/portallocator.go
+++ b/portallocator/portallocator.go
@@ -3,18 +3,10 @@ package portallocator
 import (
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net"
 	"sync"
-)
 
-var (
-	// defaultPortRangeStart indicates the first port in port range
-	defaultPortRangeStart = 49153
-	// defaultPortRangeEnd indicates the last port in port range
-	// consistent with default /proc/sys/net/ipv4/ip_local_port_range
-	// upper bound on linux
-	defaultPortRangeEnd = 60999
+	"github.com/sirupsen/logrus"
 )
 
 func sanitizePortRange(start int, end int) (newStart, newEnd int, err error) {

--- a/portallocator/portallocator_freebsd.go
+++ b/portallocator/portallocator_freebsd.go
@@ -8,20 +8,19 @@ import (
 
 func getDynamicPortRange() (start int, end int, err error) {
 	portRangeKernelSysctl := []string{"net.inet.ip.portrange.hifirst", "net.ip.portrange.hilast"}
-	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 	portRangeLowCmd := exec.Command("/sbin/sysctl", portRangeKernelSysctl[0])
 	var portRangeLowOut bytes.Buffer
 	portRangeLowCmd.Stdout = &portRangeLowOut
 	cmdErr := portRangeLowCmd.Run()
 	if cmdErr != nil {
-		return 0, 0, fmt.Errorf("port allocator - sysctl net.inet.ip.portrange.hifirst failed - %s: %v", portRangeFallback, err)
+		return 0, 0, fmt.Errorf("port allocator - sysctl net.inet.ip.portrange.hifirst failed: %v", err)
 	}
 	n, err := fmt.Sscanf(portRangeLowOut.String(), "%d", &start)
 	if n != 1 || err != nil {
 		if err == nil {
 			err = fmt.Errorf("unexpected count of parsed numbers (%d)", n)
 		}
-		return 0, 0, fmt.Errorf("port allocator - failed to parse system ephemeral port range start from %s - %s: %v", portRangeLowOut.String(), portRangeFallback, err)
+		return 0, 0, fmt.Errorf("port allocator - failed to parse system ephemeral port range start from %s: %v", portRangeLowOut.String(), err)
 	}
 
 	portRangeHighCmd := exec.Command("/sbin/sysctl", portRangeKernelSysctl[1])
@@ -29,14 +28,14 @@ func getDynamicPortRange() (start int, end int, err error) {
 	portRangeHighCmd.Stdout = &portRangeHighOut
 	cmdErr = portRangeHighCmd.Run()
 	if cmdErr != nil {
-		return 0, 0, fmt.Errorf("port allocator - sysctl net.inet.ip.portrange.hilast failed - %s: %v", portRangeFallback, err)
+		return 0, 0, fmt.Errorf("port allocator - sysctl net.inet.ip.portrange.hilast failed: %v", err)
 	}
 	n, err = fmt.Sscanf(portRangeHighOut.String(), "%d", &end)
 	if n != 1 || err != nil {
 		if err == nil {
 			err = fmt.Errorf("unexpected count of parsed numbers (%d)", n)
 		}
-		return 0, 0, fmt.Errorf("port allocator - failed to parse system ephemeral port range end from %s - %s: %v", portRangeHighOut.String(), portRangeFallback, err)
+		return 0, 0, fmt.Errorf("port allocator - failed to parse system ephemeral port range end from %s: %v", portRangeHighOut.String(), err)
 	}
 	return start, end, nil
 }

--- a/portallocator/portallocator_linux.go
+++ b/portallocator/portallocator_linux.go
@@ -8,12 +8,10 @@ import (
 
 func getDynamicPortRange() (start int, end int, err error) {
 	const portRangeKernelParam = "/proc/sys/net/ipv4/ip_local_port_range"
-	portRangeFallback := fmt.Sprintf("using fallback port range %d-%d", defaultPortRangeStart, defaultPortRangeEnd)
 	file, err := os.Open(portRangeKernelParam)
 	if err != nil {
-		return 0, 0, fmt.Errorf("port allocator - %s due to error: %v", portRangeFallback, err)
+		return 0, 0, err
 	}
-
 	defer file.Close()
 
 	n, err := fmt.Fscanf(bufio.NewReader(file), "%d\t%d", &start, &end)
@@ -21,7 +19,7 @@ func getDynamicPortRange() (start int, end int, err error) {
 		if err == nil {
 			err = fmt.Errorf("unexpected count of parsed numbers (%d)", n)
 		}
-		return 0, 0, fmt.Errorf("port allocator - failed to parse system ephemeral port range from %s - %s: %v", portRangeKernelParam, portRangeFallback, err)
+		return 0, 0, fmt.Errorf("port allocator - failed to parse system ephemeral port range from %s: %v", portRangeKernelParam, err)
 	}
 	return start, end, nil
 }

--- a/portallocator/portallocator_unix.go
+++ b/portallocator/portallocator_unix.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package portallocator
+
+const (
+	// defaultPortRangeStart indicates the first port in port range
+	defaultPortRangeStart = 49153
+	// defaultPortRangeEnd indicates the last port in port range
+	// consistent with default /proc/sys/net/ipv4/ip_local_port_range
+	// upper bound on linux
+	defaultPortRangeEnd = 60999
+)

--- a/portallocator/portallocator_windows.go
+++ b/portallocator/portallocator_windows.go
@@ -1,9 +1,11 @@
 package portallocator
 
-func init() {
+const (
+	// defaultPortRangeStart indicates the first port in port range
 	defaultPortRangeStart = 60000
+	// defaultPortRangeEnd indicates the last port in port range
 	defaultPortRangeEnd = 65000
-}
+)
 
 func getDynamicPortRange() (start int, end int, err error) {
 	return defaultPortRangeStart, defaultPortRangeEnd, nil


### PR DESCRIPTION

- portallocator: use const for default port-ranges, instead of `init()`
- portallocator: minor refactor for readability
- portallocator: log instead of discard port-range failures
    Both `getDynamicPortRange()` and `sanitizePortRange()` could produce and error, and the error message was currently discarded, silently falling back to using the default port range. This patch:
    - Moves the fallback message from `getDynamicPortRange()` to `getDefaultPortRange()`, which is where the actual fallback occurs.
    - Logs the fallback message and the error that causes the fallback.

  The message/error is currently printed at the `INFO` level, but could be raised to a `WARN`, depending on what kind of situations can cause the error.
