### PR TITLE
bridge: remove unused "others" argument from isolateNetwork()

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -323,7 +323,7 @@ func (n *bridgeNetwork) getEndpoint(eid string) (*bridgeEndpoint, error) {
 
 // Install/Removes the iptables rules needed to isolate this network
 // from each of the other networks
-func (n *bridgeNetwork) isolateNetwork(others []*bridgeNetwork, enable bool) error {
+func (n *bridgeNetwork) isolateNetwork(enable bool) error {
 	n.Lock()
 	thisConfig := n.config
 	n.Unlock()
@@ -678,8 +678,6 @@ func (d *driver) checkConflict(config *networkConfiguration) error {
 func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	defer osl.InitOSContext()()
 
-	networkList := d.getNetworks()
-
 	// Initialize handle when needed
 	d.Lock()
 	if d.nlh == nil {
@@ -719,16 +717,15 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 	// Add inter-network communication rules.
 	setupNetworkIsolationRules := func(config *networkConfiguration, i *bridgeInterface) error {
-		if err := network.isolateNetwork(networkList, true); err != nil {
-			if err = network.isolateNetwork(networkList, false); err != nil {
+		if err := network.isolateNetwork(true); err != nil {
+			if err = network.isolateNetwork(false); err != nil {
 				logrus.Warnf("Failed on removing the inter-network iptables rules on cleanup: %v", err)
 			}
 			return err
 		}
 		// register the cleanup function
 		network.registerIptCleanFunc(func() error {
-			nwList := d.getNetworks()
-			return network.isolateNetwork(nwList, false)
+			return network.isolateNetwork(false)
 		})
 		return nil
 	}


### PR DESCRIPTION
This argument was used to detect conflicts, but was later removed in 1c73b1c99c14d7f048a2318a3caf589865c76fad (https://github.com/moby/libnetwork/pull/2117 / carry of https://github.com/moby/libnetwork/pull/1534).

However, it was never removed, and we were still getting a list of all networks, without using the results.
