### PR TITLE
Ipamutils: various cleanups and refactor

### DIFF
--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -8,17 +8,31 @@ import (
 )
 
 var (
-	// PredefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
-	// (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap with the networks in `PredefinedGlobalScopeDefaultNetworks`
+	// PredefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private
+	// networks with host size 16 and 12 (172.17-31.x.x/16, 192.168.x.x/20)
+	// which do not overlap with the networks in predefinedGlobalScopeDefaultNetworks
 	PredefinedLocalScopeDefaultNetworks []*net.IPNet
-	// PredefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private networks with host size 8
-	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedLocalScopeDefaultNetworks`
+
+	// PredefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private
+	// networks with host size 8 (10.x.x.x/24) which do not overlap with the
+	// networks in PredefinedLocalScopeDefaultNetworks
 	PredefinedGlobalScopeDefaultNetworks []*net.IPNet
-	mutex                                sync.RWMutex
-	localScopeDefaultNetworks            = []*NetworkToSplit{{"172.17.0.0/16", 16}, {"172.18.0.0/16", 16}, {"172.19.0.0/16", 16},
-		{"172.20.0.0/14", 16}, {"172.24.0.0/14", 16}, {"172.28.0.0/14", 16},
-		{"192.168.0.0/16", 20}}
-	globalScopeDefaultNetworks = []*NetworkToSplit{{"10.0.0.0/8", 24}}
+
+	mutex sync.RWMutex
+
+	localScopeDefaultNetworks = []*NetworkToSplit{
+		{"172.17.0.0/16", 16},
+		{"172.18.0.0/16", 16},
+		{"172.19.0.0/16", 16},
+		{"172.20.0.0/14", 16},
+		{"172.24.0.0/14", 16},
+		{"172.28.0.0/14", 16},
+		{"192.168.0.0/16", 20},
+	}
+
+	globalScopeDefaultNetworks = []*NetworkToSplit{
+		{"10.0.0.0/8", 24},
+	}
 )
 
 // NetworkToSplit represent a network that has to be split in chunks with mask length Size.
@@ -34,12 +48,12 @@ type NetworkToSplit struct {
 func init() {
 	var err error
 	if PredefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
-		//we are going to panic in case of error as we should never get into this state
+		// we are going to panic in case of error as we should never get into this state
 		panic("InitAddressPools failed to initialize the global scope default address pool")
 	}
 
 	if PredefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
-		//we are going to panic in case of error as we should never get into this state
+		// we are going to panic in case of error as we should never get into this state
 		panic("InitAddressPools failed to initialize the local scope default address pool")
 	}
 }
@@ -56,14 +70,18 @@ func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.
 	return nil
 }
 
-// GetGlobalScopeDefaultNetworks returns PredefinedGlobalScopeDefaultNetworks
+// GetGlobalScopeDefaultNetworks returns a list of 64K IPv4 private networks with
+// host size 8 (10.x.x.x/24) which do not overlap with the networks returned by
+// GetLocalScopeDefaultNetworks
 func GetGlobalScopeDefaultNetworks() []*net.IPNet {
 	mutex.RLock()
 	defer mutex.RUnlock()
 	return PredefinedGlobalScopeDefaultNetworks
 }
 
-// GetLocalScopeDefaultNetworks returns PredefinedLocalScopeDefaultNetworks
+// GetLocalScopeDefaultNetworks returns a list of 31 IPv4 private networks with
+// host size 16 and 12 (172.17-31.x.x/16, 192.168.x.x/20) which do not overlap
+// with the networks returned by GetGlobalScopeDefaultNetworks.
 func GetLocalScopeDefaultNetworks() []*net.IPNet {
 	mutex.RLock()
 	defer mutex.RUnlock()

--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -8,6 +8,9 @@ import (
 )
 
 var (
+	// initDefaults makes sure we initialize the defaults only once
+	initDefaults sync.Once
+
 	// predefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private
 	// networks with host size 16 and 12 (172.17-31.x.x/16, 192.168.x.x/20)
 	// which do not overlap with the networks in predefinedGlobalScopeDefaultNetworks
@@ -45,16 +48,22 @@ type NetworkToSplit struct {
 	Size int    `json:"size"`
 }
 
-func init() {
+// initDefaultNetworks initializes the default address pools
+func initDefaultNetworks() {
 	var err error
-	if predefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
-		// we are going to panic in case of error as we should never get into this state
-		panic("InitAddressPools failed to initialize the global scope default address pool")
+	if len(predefinedLocalScopeDefaultNetworks) == 0 {
+		predefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks)
+		if err != nil {
+			// we are going to panic in case of error as we should never get into this state
+			panic("initDefaultNetworks failed to initialize the local scope default address pool")
+		}
 	}
-
-	if predefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
-		// we are going to panic in case of error as we should never get into this state
-		panic("InitAddressPools failed to initialize the local scope default address pool")
+	if len(predefinedGlobalScopeDefaultNetworks) == 0 {
+		predefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks)
+		if err != nil {
+			// we are going to panic in case of error as we should never get into this state
+			panic("initDefaultNetworks failed to initialize the global scope default address pool")
+		}
 	}
 }
 
@@ -76,6 +85,8 @@ func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.
 func GetGlobalScopeDefaultNetworks() []*net.IPNet {
 	mutex.RLock()
 	defer mutex.RUnlock()
+	initDefaults.Do(initDefaultNetworks)
+
 	return predefinedGlobalScopeDefaultNetworks
 }
 
@@ -85,6 +96,8 @@ func GetGlobalScopeDefaultNetworks() []*net.IPNet {
 func GetLocalScopeDefaultNetworks() []*net.IPNet {
 	mutex.RLock()
 	defer mutex.RUnlock()
+	initDefaults.Do(initDefaultNetworks)
+
 	return predefinedLocalScopeDefaultNetworks
 }
 
@@ -94,6 +107,10 @@ func ConfigGlobalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) erro
 	if defaultAddressPool == nil {
 		defaultAddressPool = globalScopeDefaultNetworks
 	}
+
+	// Prevent potential race conditions; first trigger setting the defaults
+	// if it was not run yet
+	initDefaults.Do(initDefaultNetworks)
 	return configDefaultNetworks(defaultAddressPool, &predefinedGlobalScopeDefaultNetworks)
 }
 
@@ -103,6 +120,9 @@ func ConfigLocalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) error
 	if defaultAddressPool == nil {
 		return nil
 	}
+	// Prevent potential race conditions; first trigger setting the defaults
+	// if it was not run yet
+	initDefaults.Do(initDefaultNetworks)
 	return configDefaultNetworks(defaultAddressPool, &predefinedLocalScopeDefaultNetworks)
 }
 

--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -14,7 +14,7 @@ var (
 	// PredefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private networks with host size 8
 	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedLocalScopeDefaultNetworks`
 	PredefinedGlobalScopeDefaultNetworks []*net.IPNet
-	mutex                                sync.Mutex
+	mutex                                sync.RWMutex
 	localScopeDefaultNetworks            = []*NetworkToSplit{{"172.17.0.0/16", 16}, {"172.18.0.0/16", 16}, {"172.19.0.0/16", 16},
 		{"172.20.0.0/14", 16}, {"172.24.0.0/14", 16}, {"172.28.0.0/14", 16},
 		{"192.168.0.0/16", 20}}
@@ -58,15 +58,15 @@ func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.
 
 // GetGlobalScopeDefaultNetworks returns PredefinedGlobalScopeDefaultNetworks
 func GetGlobalScopeDefaultNetworks() []*net.IPNet {
-	mutex.Lock()
-	defer mutex.Unlock()
+	mutex.RLock()
+	defer mutex.RUnlock()
 	return PredefinedGlobalScopeDefaultNetworks
 }
 
 // GetLocalScopeDefaultNetworks returns PredefinedLocalScopeDefaultNetworks
 func GetLocalScopeDefaultNetworks() []*net.IPNet {
-	mutex.Lock()
-	defer mutex.Unlock()
+	mutex.RLock()
+	defer mutex.RUnlock()
 	return PredefinedLocalScopeDefaultNetworks
 }
 

--- a/ipamutils/utils.go
+++ b/ipamutils/utils.go
@@ -8,15 +8,15 @@ import (
 )
 
 var (
-	// PredefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private
+	// predefinedLocalScopeDefaultNetworks contains a list of 31 IPv4 private
 	// networks with host size 16 and 12 (172.17-31.x.x/16, 192.168.x.x/20)
 	// which do not overlap with the networks in predefinedGlobalScopeDefaultNetworks
-	PredefinedLocalScopeDefaultNetworks []*net.IPNet
+	predefinedLocalScopeDefaultNetworks []*net.IPNet
 
-	// PredefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private
+	// predefinedGlobalScopeDefaultNetworks contains a list of 64K IPv4 private
 	// networks with host size 8 (10.x.x.x/24) which do not overlap with the
-	// networks in PredefinedLocalScopeDefaultNetworks
-	PredefinedGlobalScopeDefaultNetworks []*net.IPNet
+	// networks in predefinedLocalScopeDefaultNetworks
+	predefinedGlobalScopeDefaultNetworks []*net.IPNet
 
 	mutex sync.RWMutex
 
@@ -47,12 +47,12 @@ type NetworkToSplit struct {
 
 func init() {
 	var err error
-	if PredefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
+	if predefinedGlobalScopeDefaultNetworks, err = splitNetworks(globalScopeDefaultNetworks); err != nil {
 		// we are going to panic in case of error as we should never get into this state
 		panic("InitAddressPools failed to initialize the global scope default address pool")
 	}
 
-	if PredefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
+	if predefinedLocalScopeDefaultNetworks, err = splitNetworks(localScopeDefaultNetworks); err != nil {
 		// we are going to panic in case of error as we should never get into this state
 		panic("InitAddressPools failed to initialize the local scope default address pool")
 	}
@@ -76,7 +76,7 @@ func configDefaultNetworks(defaultAddressPool []*NetworkToSplit, result *[]*net.
 func GetGlobalScopeDefaultNetworks() []*net.IPNet {
 	mutex.RLock()
 	defer mutex.RUnlock()
-	return PredefinedGlobalScopeDefaultNetworks
+	return predefinedGlobalScopeDefaultNetworks
 }
 
 // GetLocalScopeDefaultNetworks returns a list of 31 IPv4 private networks with
@@ -85,7 +85,7 @@ func GetGlobalScopeDefaultNetworks() []*net.IPNet {
 func GetLocalScopeDefaultNetworks() []*net.IPNet {
 	mutex.RLock()
 	defer mutex.RUnlock()
-	return PredefinedLocalScopeDefaultNetworks
+	return predefinedLocalScopeDefaultNetworks
 }
 
 // ConfigGlobalScopeDefaultNetworks configures global default pool.
@@ -94,7 +94,7 @@ func ConfigGlobalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) erro
 	if defaultAddressPool == nil {
 		defaultAddressPool = globalScopeDefaultNetworks
 	}
-	return configDefaultNetworks(defaultAddressPool, &PredefinedGlobalScopeDefaultNetworks)
+	return configDefaultNetworks(defaultAddressPool, &predefinedGlobalScopeDefaultNetworks)
 }
 
 // ConfigLocalScopeDefaultNetworks configures local default pool.
@@ -103,7 +103,7 @@ func ConfigLocalScopeDefaultNetworks(defaultAddressPool []*NetworkToSplit) error
 	if defaultAddressPool == nil {
 		return nil
 	}
-	return configDefaultNetworks(defaultAddressPool, &PredefinedLocalScopeDefaultNetworks)
+	return configDefaultNetworks(defaultAddressPool, &predefinedLocalScopeDefaultNetworks)
 }
 
 // splitNetworks takes a slice of networks, split them accordingly and returns them

--- a/ipamutils/utils_test.go
+++ b/ipamutils/utils_test.go
@@ -45,13 +45,13 @@ func initGlobalScopeNetworks() []*net.IPNet {
 }
 
 func TestDefaultNetwork(t *testing.T) {
-	for _, nw := range PredefinedGlobalScopeDefaultNetworks {
+	for _, nw := range GetGlobalScopeDefaultNetworks() {
 		if ones, bits := nw.Mask.Size(); bits != 32 || ones != 24 {
 			t.Fatalf("Unexpected size for network in granular list: %v", nw)
 		}
 	}
 
-	for _, nw := range PredefinedLocalScopeDefaultNetworks {
+	for _, nw := range GetLocalScopeDefaultNetworks() {
 		if ones, bits := nw.Mask.Size(); bits != 32 || (ones != 20 && ones != 16) {
 			t.Fatalf("Unexpected size for network in broad list: %v", nw)
 		}
@@ -62,7 +62,7 @@ func TestDefaultNetwork(t *testing.T) {
 	for _, v := range originalBroadNets {
 		m[v.String()] = true
 	}
-	for _, nw := range PredefinedLocalScopeDefaultNetworks {
+	for _, nw := range GetLocalScopeDefaultNetworks() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -76,7 +76,7 @@ func TestDefaultNetwork(t *testing.T) {
 	for _, v := range originalGranularNets {
 		m[v.String()] = true
 	}
-	for _, nw := range PredefinedGlobalScopeDefaultNetworks {
+	for _, nw := range GetGlobalScopeDefaultNetworks() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -94,7 +94,7 @@ func TestConfigGlobalScopeDefaultNetworks(t *testing.T) {
 	for _, v := range originalGlobalScopeNetworks {
 		m[v.String()] = true
 	}
-	for _, nw := range PredefinedGlobalScopeDefaultNetworks {
+	for _, nw := range GetGlobalScopeDefaultNetworks() {
 		_, ok := m[nw.String()]
 		assert.Check(t, ok)
 		delete(m, nw.String())
@@ -108,11 +108,12 @@ func TestInitAddressPools(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Check for Random IPAddresses in PredefinedLocalScopeDefaultNetworks  ex: first , last and middle
-	assert.Check(t, is.Len(PredefinedLocalScopeDefaultNetworks, 512), "Failed to find PredefinedLocalScopeDefaultNetworks")
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[0].String(), "172.80.0.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[127].String(), "172.80.127.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[255].String(), "172.80.255.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[256].String(), "172.90.0.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[383].String(), "172.90.127.0/24"))
-	assert.Check(t, is.Equal(PredefinedLocalScopeDefaultNetworks[511].String(), "172.90.255.0/24"))
+	nws := GetLocalScopeDefaultNetworks()
+	assert.Check(t, is.Len(nws, 512), "Failed to find PredefinedLocalScopeDefaultNetworks")
+	assert.Check(t, is.Equal(nws[0].String(), "172.80.0.0/24"))
+	assert.Check(t, is.Equal(nws[127].String(), "172.80.127.0/24"))
+	assert.Check(t, is.Equal(nws[255].String(), "172.80.255.0/24"))
+	assert.Check(t, is.Equal(nws[256].String(), "172.90.0.0/24"))
+	assert.Check(t, is.Equal(nws[383].String(), "172.90.127.0/24"))
+	assert.Check(t, is.Equal(nws[511].String(), "172.90.255.0/24"))
 }

--- a/netutils/utils_linux.go
+++ b/netutils/utils_linux.go
@@ -96,10 +96,10 @@ func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 
 	if link == nil || len(v4Nets) == 0 {
 		// Choose from predefined local scope networks
-		v4Net, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
+		nws := ipamutils.GetLocalScopeDefaultNetworks()
+		v4Net, err := FindAvailableNetwork(nws)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "PredefinedLocalScopeDefaultNetworks List: %+v",
-				ipamutils.PredefinedLocalScopeDefaultNetworks)
+			return nil, nil, errors.Wrapf(err, "PredefinedLocalScopeDefaultNetworks List: %+v", nws)
 		}
 		v4Nets = append(v4Nets, v4Net)
 	}

--- a/netutils/utils_test.go
+++ b/netutils/utils_test.go
@@ -213,13 +213,13 @@ func TestUtilGenerateRandomMAC(t *testing.T) {
 func TestNetworkRequest(t *testing.T) {
 	defer testutils.SetupTestOSContext(t)()
 
-	nw, err := FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
+	nw, err := FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var found bool
-	for _, exp := range ipamutils.PredefinedLocalScopeDefaultNetworks {
+	for _, exp := range ipamutils.GetLocalScopeDefaultNetworks() {
 		if types.CompareIPNet(exp, nw) {
 			found = true
 			break
@@ -230,13 +230,13 @@ func TestNetworkRequest(t *testing.T) {
 		t.Fatalf("Found unexpected broad network %s", nw)
 	}
 
-	nw, err = FindAvailableNetwork(ipamutils.PredefinedGlobalScopeDefaultNetworks)
+	nw, err = FindAvailableNetwork(ipamutils.GetGlobalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	found = false
-	for _, exp := range ipamutils.PredefinedGlobalScopeDefaultNetworks {
+	for _, exp := range ipamutils.GetGlobalScopeDefaultNetworks() {
 		if types.CompareIPNet(exp, nw) {
 			found = true
 			break
@@ -254,7 +254,7 @@ func TestNetworkRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nw, err = FindAvailableNetwork(ipamutils.PredefinedLocalScopeDefaultNetworks)
+	nw, err = FindAvailableNetwork(ipamutils.GetLocalScopeDefaultNetworks())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION

- ipamutils: use RWMutex to allow concurrent reads
- ipamutils: reformat for readability, and improve godoc
- ipamutils: un-export global variables, and use accessors instead
  The `GetLocalScopeDefaultNetworks()` and `GetGlobalScopeDefaultNetworks()` protect these variables with a lock, but various parts in the code were directly accessing the variables without locks.
- ipamutils: generate default pools on first use, instead of init()
  This package defines the `NetworkToSplit` type. Curently importing the package also initializes the default address pools (which may not be needed, e.g., when used in the client.
  This patch changes initialization to happen on first use, instead of `init()`, to allow the package to be imported without initializing these pools.

