### PR TITLE
Make sure IPv6 is enabled for IP6tables

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -779,13 +779,13 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		{d.config.EnableIPTables, network.setupIP4Tables},
 
 		// Setup IP6Tables.
-		{d.config.EnableIP6Tables, network.setupIP6Tables},
+		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupIP6Tables},
 
 		//We want to track firewalld configuration so that
 		//if it is started/reloaded, the rules can be applied correctly
 		{d.config.EnableIPTables, network.setupFirewalld},
 		// same for IPv6
-		{d.config.EnableIP6Tables, network.setupFirewalld6},
+		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupFirewalld6},
 
 		// Setup DefaultGatewayIPv4
 		{config.DefaultGatewayIPv4 != nil, setupGatewayIPv4},


### PR DESCRIPTION
Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>

Relates to https://github.com/moby/moby/issues/41774