### PR TITLE
IP6Tables cleanup

### DIFF
--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -416,6 +416,11 @@ func (d *driver) configure(option map[string]interface{}) error {
 		})
 	}
 
+	if config.EnableIPTables && config.EnableIP6Tables && config.EnableUserlandProxy {
+		logrus.Warn("userland proxy cannot be used if iptables and ip6tables are enabled -> disabling it")
+		config.EnableUserlandProxy = false
+	}
+
 	if config.EnableIPForwarding {
 		err = setupIPForwarding(config.EnableIPTables, config.EnableIP6Tables)
 		if err != nil {

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -178,7 +178,11 @@ func (n *bridgeNetwork) setupIPTables(ipVersion iptables.IPVersion, maskedAddr *
 			return iptable.ProgramChain(filterChain, config.BridgeName, hairpinMode, false)
 		})
 
-		n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
+		if ipVersion == iptables.IPv4 {
+			n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
+		} else {
+			n.portMapperV6.SetIptablesChain(natChain, n.getNetworkBridgeName())
+		}
 	}
 
 	d.Lock()

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -533,8 +533,10 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	}
 
 	path := iptablesPath
+	commandName := "iptables"
 	if iptable.Version == IPv6 {
 		path = ip6tablesPath
+		commandName = "ip6tables"
 	}
 
 	logrus.Debugf("%s, %v", path, args)
@@ -542,7 +544,7 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	startTime := time.Now()
 	output, err := exec.Command(path, args...).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("iptables failed: iptables %v: %s (%s)", strings.Join(args, " "), output, err)
+		return nil, fmt.Errorf("iptables failed: %s %v: %s (%s)", commandName, strings.Join(args, " "), output, err)
 	}
 
 	return filterOutput(startTime, output, args...), err


### PR DESCRIPTION
This fixes multiple issues found in the IP6Tables feature.

In combination with #2600 this should handle moby/moby#41774

- [x] Fixed iptables command name in error log (see #2603)
- [x] Fixed initialization of IPv6 port mapper (see #2603)
- [x] Fix for `bind: address already in use`