### PR TITLE
Fix IPv6 Port Forwarding for the Bridge Driver

### DIFF
--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -8,6 +8,16 @@ import (
 	"github.com/ishidawataru/sctp"
 )
 
+// ipVersion refers to IP version - v4 or v6
+type ipVersion string
+
+const (
+	// IPv4 is version 4
+	ipv4 ipVersion = "4"
+	// IPv4 is version 6
+	ipv6 ipVersion = "6"
+)
+
 // Proxy defines the behavior of a proxy. It forwards traffic back and forth
 // between two endpoints : the frontend and the backend.
 // It can be used to do software port-mapping between two addresses.

--- a/cmd/proxy/sctp_proxy.go
+++ b/cmd/proxy/sctp_proxy.go
@@ -19,7 +19,12 @@ type SCTPProxy struct {
 
 // NewSCTPProxy creates a new SCTPProxy.
 func NewSCTPProxy(frontendAddr, backendAddr *sctp.SCTPAddr) (*SCTPProxy, error) {
-	listener, err := sctp.ListenSCTP("sctp", frontendAddr)
+	// detect version of hostIP to bind only to correct version
+	ipVersion := ipv4
+	if frontendAddr.IPAddrs[0].IP.To4() == nil {
+		ipVersion = ipv6
+	}
+	listener, err := sctp.ListenSCTP("sctp"+string(ipVersion), frontendAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/proxy/tcp_proxy.go
+++ b/cmd/proxy/tcp_proxy.go
@@ -17,7 +17,12 @@ type TCPProxy struct {
 
 // NewTCPProxy creates a new TCPProxy.
 func NewTCPProxy(frontendAddr, backendAddr *net.TCPAddr) (*TCPProxy, error) {
-	listener, err := net.ListenTCP("tcp", frontendAddr)
+	// detect version of hostIP to bind only to correct version
+	ipVersion := ipv4
+	if frontendAddr.IP.To4() == nil {
+		ipVersion = ipv6
+	}
+	listener, err := net.ListenTCP("tcp"+string(ipVersion), frontendAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/proxy/udp_proxy.go
+++ b/cmd/proxy/udp_proxy.go
@@ -55,7 +55,12 @@ type UDPProxy struct {
 
 // NewUDPProxy creates a new UDPProxy.
 func NewUDPProxy(frontendAddr, backendAddr *net.UDPAddr) (*UDPProxy, error) {
-	listener, err := net.ListenUDP("udp", frontendAddr)
+	// detect version of hostIP to bind only to correct version
+	ipVersion := ipv4
+	if frontendAddr.IP.To4() == nil {
+		ipVersion = ipv6
+	}
+	listener, err := net.ListenUDP("udp"+string(ipVersion), frontendAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -199,7 +199,7 @@ func TestBridge(t *testing.T) {
 	if !ok {
 		t.Fatalf("Unexpected format for port mapping in endpoint operational data")
 	}
-	if len(pm) != 5 {
+	if len(pm) != 10 {
 		t.Fatalf("Incomplete data for port mapping in endpoint operational data: %d", len(pm))
 	}
 }

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -151,20 +151,16 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	}
 
 	containerIP, containerPort := getIPAndPort(m.container)
-	if pm.checkIP(hostIP) {
-		if err := pm.AppendForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
-			return nil, err
-		}
+	if err := pm.AppendForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
+		return nil, err
 	}
 
 	cleanup := func() error {
 		// need to undo the iptables rules before we return
 		m.userlandProxy.Stop()
-		if pm.checkIP(hostIP) {
-			pm.DeleteForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
-			if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
-				return err
-			}
+		pm.DeleteForwardingTableEntry(m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
+		if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
+			return err
 		}
 
 		return nil

--- a/portmapper/mapper_linux.go
+++ b/portmapper/mapper_linux.go
@@ -44,11 +44,3 @@ func (pm *PortMapper) forward(action iptables.Action, proto string, sourceIP net
 	}
 	return pm.chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort, pm.bridgeName)
 }
-
-// checkIP checks if IP is valid and matching to chain version
-func (pm *PortMapper) checkIP(ip net.IP) bool {
-	if pm.chain == nil || pm.chain.IPTable.Version == iptables.IPv4 {
-		return ip.To4() != nil
-	}
-	return ip.To16() != nil
-}

--- a/portmapper/proxy.go
+++ b/portmapper/proxy.go
@@ -19,6 +19,16 @@ type userlandProxy interface {
 	Stop() error
 }
 
+// ipVersion refers to IP version - v4 or v6
+type ipVersion string
+
+const (
+	// IPv4 is version 4
+	ipv4 ipVersion = "4"
+	// IPv4 is version 6
+	ipv6 ipVersion = "6"
+)
+
 // proxyCommand wraps an exec.Cmd to run the userland TCP and UDP
 // proxies as separate processes.
 type proxyCommand struct {
@@ -77,21 +87,27 @@ func (p *proxyCommand) Stop() error {
 // port allocations on bound port, because without userland proxy we using
 // iptables rules and not net.Listen
 type dummyProxy struct {
-	listener io.Closer
-	addr     net.Addr
+	listener  io.Closer
+	addr      net.Addr
+	ipVersion ipVersion
 }
 
 func newDummyProxy(proto string, hostIP net.IP, hostPort int) (userlandProxy, error) {
+	// detect version of hostIP to bind only to correct version
+	version := ipv4
+	if hostIP.To4() == nil {
+		version = ipv6
+	}
 	switch proto {
 	case "tcp":
 		addr := &net.TCPAddr{IP: hostIP, Port: hostPort}
-		return &dummyProxy{addr: addr}, nil
+		return &dummyProxy{addr: addr, ipVersion: version}, nil
 	case "udp":
 		addr := &net.UDPAddr{IP: hostIP, Port: hostPort}
-		return &dummyProxy{addr: addr}, nil
+		return &dummyProxy{addr: addr, ipVersion: version}, nil
 	case "sctp":
 		addr := &sctp.SCTPAddr{IPAddrs: []net.IPAddr{{IP: hostIP}}, Port: hostPort}
-		return &dummyProxy{addr: addr}, nil
+		return &dummyProxy{addr: addr, ipVersion: version}, nil
 	default:
 		return nil, fmt.Errorf("Unknown addr type: %s", proto)
 	}
@@ -100,19 +116,19 @@ func newDummyProxy(proto string, hostIP net.IP, hostPort int) (userlandProxy, er
 func (p *dummyProxy) Start() error {
 	switch addr := p.addr.(type) {
 	case *net.TCPAddr:
-		l, err := net.ListenTCP("tcp", addr)
+		l, err := net.ListenTCP("tcp"+string(p.ipVersion), addr)
 		if err != nil {
 			return err
 		}
 		p.listener = l
 	case *net.UDPAddr:
-		l, err := net.ListenUDP("udp", addr)
+		l, err := net.ListenUDP("udp"+string(p.ipVersion), addr)
 		if err != nil {
 			return err
 		}
 		p.listener = l
 	case *sctp.SCTPAddr:
-		l, err := sctp.ListenSCTP("sctp", addr)
+		l, err := sctp.ListenSCTP("sctp"+string(p.ipVersion), addr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
1. Allocate either a IPv4 and/or IPv6 Port Binding (HostIP, HostPort, ContainerIP,
ContainerPort) based on the input and system parameters
2. Update the userland proxy as well as dummy proxy (inside port mapper) to
specifically listen to either the IPv4 or IPv6 network

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>