### PR TITLE
Add support for nftables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 bin/
 tags
 .DS_Store
+.idea
 
 # Folders
 integration-tmp/

--- a/controller.go
+++ b/controller.go
@@ -48,6 +48,7 @@ import (
 	"net"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -1381,6 +1382,32 @@ func (c *controller) iptablesEnabled() bool {
 		return false
 	}
 	enabled, ok := cfgGeneric["EnableIPTables"].(bool)
+	if !ok {
+		// unless user explicitly stated, assume iptable is enabled
+		enabled = true
+	}
+	return enabled
+}
+
+func (c *controller) nftablesEnabled() bool {
+	c.Lock()
+	defer c.Unlock()
+
+	debug.PrintStack()
+
+	if c.cfg == nil {
+		return false
+	}
+	// parse map cfg["bridge"]["generic"]["EnableIPTable"]
+	cfgBridge, ok := c.cfg.Daemon.DriverCfg["bridge"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	cfgGeneric, ok := cfgBridge[netlabel.GenericData].(options.Generic)
+	if !ok {
+		return false
+	}
+	enabled, ok := cfgGeneric["EnableNFTables"].(bool)
 	if !ok {
 		// unless user explicitly stated, assume iptable is enabled
 		enabled = true

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -15,9 +15,12 @@ import (
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/discoverapi"
 	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/firewallapi"
+	"github.com/docker/libnetwork/firewalld"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/netutils"
+	"github.com/docker/libnetwork/nftables"
 	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
@@ -50,14 +53,15 @@ func (d defaultBridgeNetworkConflict) Error() string {
 	return fmt.Sprintf("Stale default bridge network %s", d.ID)
 }
 
-type iptableCleanFunc func() error
-type iptablesCleanFuncs []iptableCleanFunc
+type tableCleanFunc func() error
+type tablesCleanFuncs []tableCleanFunc
 
 // configuration info for the "bridge" driver.
 type configuration struct {
 	EnableIPForwarding  bool
 	EnableIPTables      bool
 	EnableIP6Tables     bool
+	EnableNFTables      bool
 	EnableUserlandProxy bool
 	UserlandProxyPath   string
 }
@@ -69,6 +73,7 @@ type networkConfiguration struct {
 	EnableIPv6           bool
 	EnableIPMasquerade   bool
 	EnableICC            bool
+	EnableNFTables       bool
 	InhibitIPv4          bool
 	Mtu                  int
 	DefaultBindingIP     net.IP
@@ -136,21 +141,21 @@ type bridgeNetwork struct {
 	portMapper    *portmapper.PortMapper
 	portMapperV6  *portmapper.PortMapper
 	driver        *driver // The network's driver
-	iptCleanFuncs iptablesCleanFuncs
+	iptCleanFuncs tablesCleanFuncs
 	sync.Mutex
 }
 
 type driver struct {
 	config            *configuration
 	network           *bridgeNetwork
-	natChain          *iptables.ChainInfo
-	filterChain       *iptables.ChainInfo
-	isolationChain1   *iptables.ChainInfo
-	isolationChain2   *iptables.ChainInfo
-	natChainV6        *iptables.ChainInfo
-	filterChainV6     *iptables.ChainInfo
-	isolationChain1V6 *iptables.ChainInfo
-	isolationChain2V6 *iptables.ChainInfo
+	natChain          firewallapi.FirewallChain
+	filterChain       firewallapi.FirewallChain
+	isolationChain1   firewallapi.FirewallChain
+	isolationChain2   firewallapi.FirewallChain
+	natChainV6        firewallapi.FirewallChain
+	filterChainV6     firewallapi.FirewallChain
+	isolationChain1V6 firewallapi.FirewallChain
+	isolationChain2V6 firewallapi.FirewallChain
 	networks          map[string]*bridgeNetwork
 	store             datastore.DataStore
 	nlh               *netlink.Handle
@@ -279,11 +284,11 @@ func parseErr(label, value, errString string) error {
 	return types.BadRequestErrorf("failed to parse %s value: %v (%s)", label, value, errString)
 }
 
-func (n *bridgeNetwork) registerIptCleanFunc(clean iptableCleanFunc) {
+func (n *bridgeNetwork) registerIptCleanFunc(clean tableCleanFunc) {
 	n.iptCleanFuncs = append(n.iptCleanFuncs, clean)
 }
 
-func (n *bridgeNetwork) getDriverChains(version iptables.IPVersion) (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
+func (n *bridgeNetwork) getDriverChains(version iptables.IPVersion) (firewallapi.FirewallChain, firewallapi.FirewallChain, firewallapi.FirewallChain, firewallapi.FirewallChain, error) {
 	n.Lock()
 	defer n.Unlock()
 
@@ -350,14 +355,14 @@ func (d *driver) configure(option map[string]interface{}) error {
 	var (
 		config            *configuration
 		err               error
-		natChain          *iptables.ChainInfo
-		filterChain       *iptables.ChainInfo
-		isolationChain1   *iptables.ChainInfo
-		isolationChain2   *iptables.ChainInfo
-		natChainV6        *iptables.ChainInfo
-		filterChainV6     *iptables.ChainInfo
-		isolationChain1V6 *iptables.ChainInfo
-		isolationChain2V6 *iptables.ChainInfo
+		natChain          firewallapi.FirewallChain
+		filterChain       firewallapi.FirewallChain
+		isolationChain1   firewallapi.FirewallChain
+		isolationChain2   firewallapi.FirewallChain
+		natChainV6        firewallapi.FirewallChain
+		filterChainV6     firewallapi.FirewallChain
+		isolationChain1V6 firewallapi.FirewallChain
+		isolationChain2V6 firewallapi.FirewallChain
 	)
 
 	genericData, ok := option[netlabel.GenericData]
@@ -386,38 +391,49 @@ func (d *driver) configure(option map[string]interface{}) error {
 		}
 	}
 
-	if config.EnableIPTables {
-		removeIPChains(iptables.IPv4)
+	var tablev4 firewallapi.IPVersion
+	var tablev6 firewallapi.IPVersion
 
-		natChain, filterChain, isolationChain1, isolationChain2, err = setupIPChains(config, iptables.IPv4)
+	if config.EnableNFTables {
+		tablev4 = nftables.IPv4
+		tablev6 = nftables.IPv6
+	} else {
+		tablev4 = iptables.IPv4
+		tablev6 = iptables.IPv6
+	}
+
+	if config.EnableIPTables {
+		removeIPChains(tablev4)
+
+		natChain, filterChain, isolationChain1, isolationChain2, err = setupIPChains(config, tablev4)
 		if err != nil {
 			return err
 		}
 
 		// Make sure on firewall reload, first thing being re-played is chains creation
-		iptables.OnReloaded(func() {
+		firewalld.OnReloaded(func() {
 			logrus.Debugf("Recreating iptables chains on firewall reload")
-			setupIPChains(config, iptables.IPv4)
+			setupIPChains(config, tablev4)
 		})
 	}
 
 	if config.EnableIP6Tables {
-		removeIPChains(iptables.IPv6)
+		removeIPChains(tablev6)
 
-		natChainV6, filterChainV6, isolationChain1V6, isolationChain2V6, err = setupIPChains(config, iptables.IPv6)
+		natChainV6, filterChainV6, isolationChain1V6, isolationChain2V6, err = setupIPChains(config, tablev6)
 		if err != nil {
 			return err
 		}
 
 		// Make sure on firewall reload, first thing being re-played is chains creation
-		iptables.OnReloaded(func() {
+		firewalld.OnReloaded(func() {
 			logrus.Debugf("Recreating ip6tables chains on firewall reload")
-			setupIPChains(config, iptables.IPv6)
+			setupIPChains(config, tablev6)
 		})
 	}
 
 	if config.EnableIPForwarding {
-		err = setupIPForwarding(config.EnableIPTables, config.EnableIP6Tables)
+		err = setupIPForwarding(config.EnableIPTables, config.EnableIP6Tables, config.EnableNFTables)
 		if err != nil {
 			logrus.Warn(err)
 			return err
@@ -721,7 +737,7 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 	setupNetworkIsolationRules := func(config *networkConfiguration, i *bridgeInterface) error {
 		if err := network.isolateNetwork(networkList, true); err != nil {
 			if err = network.isolateNetwork(networkList, false); err != nil {
-				logrus.Warnf("Failed on removing the inter-network iptables rules on cleanup: %v", err)
+				logrus.Warnf("Failed on removing the inter-network rules on cleanup: %v", err)
 			}
 			return err
 		}
@@ -780,6 +796,12 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 		// Setup IP6Tables.
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupIP6Tables},
+
+		// Setup NFTables.
+		{d.config.EnableNFTables, network.setupNFTables},
+
+		// Setup NFTables v6
+		{config.EnableIPv6 && d.config.EnableNFTables, network.setupNF6Tables},
 
 		//We want to track firewalld configuration so that
 		//if it is started/reloaded, the rules can be applied correctly
@@ -1435,7 +1457,8 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 
 			l := newLink(parentEndpoint.addr.IP.String(),
 				endpoint.addr.IP.String(),
-				ec.ExposedPorts, network.config.BridgeName)
+				ec.ExposedPorts, network.config.BridgeName,
+				d.config.EnableNFTables)
 			if enable {
 				err = l.Enable()
 				if err != nil {
@@ -1468,7 +1491,8 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 
 		l := newLink(endpoint.addr.IP.String(),
 			childEndpoint.addr.IP.String(),
-			childEndpoint.extConnConfig.ExposedPorts, network.config.BridgeName)
+			childEndpoint.extConnConfig.ExposedPorts, network.config.BridgeName,
+			d.config.EnableNFTables)
 		if enable {
 			err = l.Enable()
 			if err != nil {

--- a/drivers/bridge/bridge_test.go
+++ b/drivers/bridge/bridge_test.go
@@ -468,7 +468,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 // Verify the network isolation rules are installed for each network
 func verifyV4INCEntries(networks map[string]*bridgeNetwork, t *testing.T) {
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	out1, err := iptable.Raw("-S", IsolationChain1)
 	if err != nil {
 		t.Fatal(err)
@@ -716,7 +716,7 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	d := newDriver()
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	config := &configuration{
 		EnableIPTables: true,
@@ -1008,7 +1008,7 @@ func TestCleanupIptableRules(t *testing.T) {
 			t.Fatalf("Error setting up ip chains for %s: %v", version, err)
 		}
 
-		iptable := iptables.GetIptable(version)
+		iptable := iptables.GetTable(version)
 		for _, chainInfo := range bridgeChain {
 			if !iptable.ExistChain(chainInfo.Name, chainInfo.Table) {
 				t.Fatalf("iptables version %s chain %s of %s table should have been created", version, chainInfo.Name, chainInfo.Table)

--- a/drivers/bridge/link.go
+++ b/drivers/bridge/link.go
@@ -4,28 +4,31 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/docker/libnetwork/firewalld"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/types"
 	"github.com/sirupsen/logrus"
 )
 
 type link struct {
-	parentIP string
-	childIP  string
-	ports    []types.TransportPort
-	bridge   string
+	parentIP       string
+	childIP        string
+	ports          []types.TransportPort
+	bridge         string
+	enableNFTables bool
 }
 
 func (l *link) String() string {
 	return fmt.Sprintf("%s <-> %s [%v] on %s", l.parentIP, l.childIP, l.ports, l.bridge)
 }
 
-func newLink(parentIP, childIP string, ports []types.TransportPort, bridge string) *link {
+func newLink(parentIP, childIP string, ports []types.TransportPort, bridge string, enableNFTables bool) *link {
 	return &link{
-		childIP:  childIP,
-		parentIP: parentIP,
-		ports:    ports,
-		bridge:   bridge,
+		childIP:        childIP,
+		parentIP:       parentIP,
+		ports:          ports,
+		bridge:         bridge,
+		enableNFTables: enableNFTables,
 	}
 
 }
@@ -33,25 +36,25 @@ func newLink(parentIP, childIP string, ports []types.TransportPort, bridge strin
 func (l *link) Enable() error {
 	// -A == iptables append flag
 	linkFunction := func() error {
-		return linkContainers("-A", l.parentIP, l.childIP, l.ports, l.bridge, false)
+		return linkContainers("-A", l.parentIP, l.childIP, l.ports, l.bridge, l.enableNFTables, false)
 	}
 
-	iptables.OnReloaded(func() { linkFunction() })
+	firewalld.OnReloaded(func() { linkFunction() })
 	return linkFunction()
 }
 
 func (l *link) Disable() {
 	// -D == iptables delete flag
-	err := linkContainers("-D", l.parentIP, l.childIP, l.ports, l.bridge, true)
+	err := linkContainers("-D", l.parentIP, l.childIP, l.ports, l.bridge, l.enableNFTables, true)
 	if err != nil {
-		logrus.Errorf("Error removing IPTables rules for a link %s due to %s", l.String(), err.Error())
+		logrus.Errorf("Error removing rules for a link %s due to %s", l.String(), err.Error())
 	}
 	// Return proper error once we move to use a proper iptables package
 	// that returns typed errors
 }
 
 func linkContainers(action, parentIP, childIP string, ports []types.TransportPort, bridge string,
-	ignoreErrors bool) error {
+	enableNFTables bool, ignoreErrors bool) error {
 	var nfAction iptables.Action
 
 	switch action {

--- a/drivers/bridge/link_test.go
+++ b/drivers/bridge/link_test.go
@@ -17,7 +17,31 @@ func getPorts() []types.TransportPort {
 func TestLinkNew(t *testing.T) {
 	ports := getPorts()
 
-	link := newLink("172.0.17.3", "172.0.17.2", ports, "docker0")
+	link := newLink("172.0.17.3", "172.0.17.2", ports, "docker0", false)
+
+	if link == nil {
+		t.FailNow()
+	}
+	if link.parentIP != "172.0.17.3" {
+		t.Fail()
+	}
+	if link.childIP != "172.0.17.2" {
+		t.Fail()
+	}
+	for i, p := range link.ports {
+		if p != ports[i] {
+			t.Fail()
+		}
+	}
+	if link.bridge != "docker0" {
+		t.Fail()
+	}
+}
+
+func TestLinkNFTablesNew(t *testing.T) {
+	ports := getPorts()
+
+	link := newLink("172.0.17.3", "172.0.17.2", ports, "docker0", true)
 
 	if link == nil {
 		t.FailNow()

--- a/drivers/bridge/setup_firewalld.go
+++ b/drivers/bridge/setup_firewalld.go
@@ -1,6 +1,6 @@
 package bridge
 
-import "github.com/docker/libnetwork/iptables"
+import "github.com/docker/libnetwork/firewalld"
 
 func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeInterface) error {
 	d := n.driver
@@ -13,8 +13,8 @@ func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeIn
 		return IPTableCfgError(config.BridgeName)
 	}
 
-	iptables.OnReloaded(func() { n.setupIP4Tables(config, i) })
-	iptables.OnReloaded(n.portMapper.ReMapAll)
+	firewalld.OnReloaded(func() { n.setupIP4Tables(config, i) })
+	firewalld.OnReloaded(n.portMapper.ReMapAll)
 	return nil
 }
 
@@ -29,7 +29,7 @@ func (n *bridgeNetwork) setupFirewalld6(config *networkConfiguration, i *bridgeI
 		return IPTableCfgError(config.BridgeName)
 	}
 
-	iptables.OnReloaded(func() { n.setupIP6Tables(config, i) })
-	iptables.OnReloaded(n.portMapperV6.ReMapAll)
+	firewalld.OnReloaded(func() { n.setupIP6Tables(config, i) })
+	firewalld.OnReloaded(n.portMapperV6.ReMapAll)
 	return nil
 }

--- a/drivers/bridge/setup_ip_forwarding_test.go
+++ b/drivers/bridge/setup_ip_forwarding_test.go
@@ -17,7 +17,7 @@ func TestSetupIPForwarding(t *testing.T) {
 	}
 
 	// Set IP Forwarding
-	if err := setupIPForwarding(true, true); err != nil {
+	if err := setupIPForwarding(true, true, false); err != nil {
 		t.Fatalf("Failed to setup IP forwarding: %v", err)
 	}
 

--- a/drivers/bridge/setup_tables_test.go
+++ b/drivers/bridge/setup_tables_test.go
@@ -27,15 +27,15 @@ func TestProgramIPTable(t *testing.T) {
 
 	// Store various iptables chain rules we care for.
 	rules := []struct {
-		rule  iptRule
+		rule  firewallRule
 		descr string
 	}{
-		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-d", "127.1.2.3", "-i", "lo", "-o", "lo", "-j", "DROP"}}, "Test Loopback"},
-		{iptRule{table: iptables.Nat, chain: "POSTROUTING", preArgs: []string{"-t", "nat"}, args: []string{"-s", iptablesTestBridgeIP, "!", "-o", DefaultBridgeName, "-j", "MASQUERADE"}}, "NAT Test"},
-		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-o", DefaultBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}}, "Test ACCEPT INCOMING"},
-		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "!", "-o", DefaultBridgeName, "-j", "ACCEPT"}}, "Test ACCEPT NON_ICC OUTGOING"},
-		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "-o", DefaultBridgeName, "-j", "ACCEPT"}}, "Test enable ICC"},
-		{iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "-o", DefaultBridgeName, "-j", "DROP"}}, "Test disable ICC"},
+		{firewallRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-d", "127.1.2.3", "-i", "lo", "-o", "lo", "-j", "DROP"}}, "Test Loopback"},
+		{firewallRule{table: iptables.Nat, chain: "POSTROUTING", preArgs: []string{"-t", "nat"}, args: []string{"-s", iptablesTestBridgeIP, "!", "-o", DefaultBridgeName, "-j", "MASQUERADE"}}, "NAT Test"},
+		{firewallRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-o", DefaultBridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}}, "Test ACCEPT INCOMING"},
+		{firewallRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "!", "-o", DefaultBridgeName, "-j", "ACCEPT"}}, "Test ACCEPT NON_ICC OUTGOING"},
+		{firewallRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "-o", DefaultBridgeName, "-j", "ACCEPT"}}, "Test enable ICC"},
+		{firewallRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", DefaultBridgeName, "-o", DefaultBridgeName, "-j", "DROP"}}, "Test disable ICC"},
 	}
 
 	// Assert the chain rules' insertion and removal.
@@ -94,13 +94,13 @@ func createTestBridge(config *networkConfiguration, br *bridgeInterface, t *test
 }
 
 // Assert base function which pushes iptables chain rules on insertion and removal.
-func assertIPTableChainProgramming(rule iptRule, descr string, t *testing.T) {
+func assertIPTableChainProgramming(rule firewallRule, descr string, t *testing.T) {
 	// Add
 	if err := programChainRule(iptables.IPv4, rule, descr, true); err != nil {
 		t.Fatalf("Failed to program iptable rule %s: %s", descr, err.Error())
 	}
 
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	if iptable.Exists(rule.table, rule.chain, rule.args...) == false {
 		t.Fatalf("Failed to effectively program iptable rule: %s", descr)
 	}

--- a/drivers/overlay/encryption.go
+++ b/drivers/overlay/encryption.go
@@ -211,7 +211,7 @@ func programMangle(vni uint32, add bool) (err error) {
 	)
 
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	if add == iptable.Exists(iptables.Mangle, chain, rule...) {
 		return
@@ -243,7 +243,7 @@ func programInput(vni uint32, add bool) (err error) {
 	)
 
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	if !add {
 		action = iptables.Delete

--- a/drivers/overlay/filter.go
+++ b/drivers/overlay/filter.go
@@ -21,7 +21,7 @@ func filterWait() func() {
 
 func chainExists(cname string) bool {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	if _, err := iptable.Raw("-L", cname); err != nil {
 		return false
 	}
@@ -31,7 +31,7 @@ func chainExists(cname string) bool {
 
 func setupGlobalChain() {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	// Because of an ungraceful shutdown, chain could already be present
 	if !chainExists(globalChain) {
 		if err := iptable.RawCombinedOutput("-N", globalChain); err != nil {
@@ -49,7 +49,7 @@ func setupGlobalChain() {
 
 func setNetworkChain(cname string, remove bool) error {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	// Initialize the onetime global overlay chain
 	filterOnce.Do(setupGlobalChain)
 
@@ -99,7 +99,7 @@ func setFilters(cname, brName string, remove bool) error {
 		opt = "-D"
 	}
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	// Every time we set filters for a new subnet make sure to move the global overlay hook to the top of the both the OUTPUT and forward chains
 	if !remove {

--- a/firewall_linux.go
+++ b/firewall_linux.go
@@ -1,7 +1,10 @@
 package libnetwork
 
 import (
+	"github.com/docker/libnetwork/firewallapi"
+	"github.com/docker/libnetwork/firewalld"
 	"github.com/docker/libnetwork/iptables"
+	"github.com/docker/libnetwork/nftables"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +16,7 @@ var (
 
 func setupArrangeUserFilterRule(c *controller) {
 	ctrl = c
-	iptables.OnReloaded(arrangeUserFilterRule)
+	firewalld.OnReloaded(arrangeUserFilterRule)
 }
 
 // This chain allow users to configure firewall policies in a way that persists
@@ -23,23 +26,30 @@ func setupArrangeUserFilterRule(c *controller) {
 // IPTableForwarding is disabled, because it contains rules configured by user that
 // are beyond docker engine's control.
 func arrangeUserFilterRule() {
-	if ctrl == nil || !ctrl.iptablesEnabled() {
+	if ctrl == nil || (!ctrl.iptablesEnabled() && !ctrl.nftablesEnabled()) {
 		return
 	}
+
+	var table firewallapi.FirewallTable
+
+	if ctrl.nftablesEnabled() {
+		table = nftables.GetTable(nftables.IPv4)
+	} else {
+		table = iptables.GetTable(iptables.IPv4)
+	}
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
-	_, err := iptable.NewChain(userChain, iptables.Filter, false)
+	_, err := table.NewChain(userChain, iptables.Filter, false)
 	if err != nil {
 		logrus.Warnf("Failed to create %s chain: %v", userChain, err)
 		return
 	}
 
-	if err = iptable.AddReturnRule(userChain); err != nil {
+	if err = table.AddReturnRule(userChain); err != nil {
 		logrus.Warnf("Failed to add the RETURN rule for %s: %v", userChain, err)
 		return
 	}
 
-	err = iptable.EnsureJumpRule("FORWARD", userChain)
+	err = table.EnsureJumpRule("FORWARD", userChain)
 	if err != nil {
 		logrus.Warnf("Failed to ensure the jump rule for %s: %v", userChain, err)
 	}

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -17,7 +17,7 @@ const (
 )
 
 func TestUserChain(t *testing.T) {
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	nc, err := New()
 	assert.NilError(t, err)
@@ -80,7 +80,7 @@ func TestUserChain(t *testing.T) {
 }
 
 func getRules(t *testing.T, chain string) []string {
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	t.Helper()
 	output, err := iptable.Raw("-S", chain)
@@ -94,7 +94,7 @@ func getRules(t *testing.T, chain string) []string {
 }
 
 func resetIptables(t *testing.T) {
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	t.Helper()
 	_, err := iptable.Raw("-F", fwdChainName)

--- a/firewallapi/firewallapi.go
+++ b/firewallapi/firewallapi.go
@@ -1,0 +1,74 @@
+package firewallapi
+
+import (
+	"net"
+)
+
+// Action signifies the nftable action.
+type Action string
+
+// Policy is the default nftable policies
+type Policy string
+
+// Table refers to Nat, Filter or Mangle.
+type Table string
+
+// IPVersion refers to IP version, v4 or v6
+type IPVersion string
+
+const (
+	// Nat table is used for nat translation rules.
+	Nat Table = "nat"
+	// Filter table is used for filter rules.
+	Filter Table = "filter"
+	// Mangle table is used for mangling the packet.
+	Mangle Table = "mangle"
+)
+
+// VersionTable defines struct with IPVersion
+type VersionTable struct {
+	Version IPVersion
+}
+
+// ChainError is returned to represent errors during nf table operation.
+type ChainError struct {
+	Chain  string
+	Output []byte
+}
+
+type FirewallTable interface {
+	// GetTable returns the default implementation for a given
+	// firewall type
+	GetTable(ipv IPVersion) *VersionTable
+	NewChain(name string, table Table, hairpinMode bool) (FirewallChain, error)
+	LoopbackByVersion() string
+	ProgramChain(c FirewallChain, bridgeName string, hairpinMode, enable bool) error
+	RemoveExistingChain(name string, table Table) error
+	ProgramRule(table Table, chain string, action Action, args []string) error
+	Exists(table Table, chain string, rule ...string) bool
+	ExistsNative(table Table, chain string, rule ...string) bool
+	exists(native bool, table Table, chain string, rule ...string) bool
+	existsRaw(table Table, chain string, rule ...string) bool
+	Raw(args ...string) ([]byte, error)
+	raw(args ...string) ([]byte, error)
+	RawCombinedOutput(args ...string) error
+	RawCombinedOutputNative(args ...string) error
+	ExistChain(chain string, table Table) bool
+	SetDefaultPolicy(table Table, chain string, policy Policy) error
+	AddReturnRule(chain string) error
+	EnsureJumpRule(fromChain, toChain string) error
+}
+
+type FirewallChain interface {
+	Forward(action Action, ip net.IP, port int, proto, destAddr string, destPort int, bridgeName string) error
+	Link(action Action, ip1, ip2 net.IP, port int, proto string, bridgeName string) error
+	DeleteRule(version IPVersion, table Table, chain string, rule ...string) error
+	Prerouting(action Action, args ...string) error
+	Output(action Action, args ...string) error
+	Remove() error
+	GetName() string
+	GetTable() Table
+	SetTable(Table)
+	GetHairpinMode() bool
+	GetFirewallTable() FirewallTable
+}

--- a/firewalld/firewalld.go
+++ b/firewalld/firewalld.go
@@ -1,4 +1,4 @@
-package iptables
+package firewalld
 
 import (
 	"fmt"
@@ -18,6 +18,9 @@ const (
 	IP6Tables IPV = "ipv6"
 	// Ebtables point to bridge table
 	Ebtables IPV = "eb"
+	// NFtables points to a nft table
+	// FIXME: firewalld somehow doesn't support direct passthrough for NFT yet
+	// We should reach out to the maintainers to find out whether ipv4|ipv6 handle this
 )
 
 const (
@@ -59,7 +62,7 @@ type ZoneSettings struct {
 var (
 	connection *Conn
 
-	firewalldRunning bool      // is Firewalld service running
+	FirewalldRunning bool      // is Firewalld service running
 	onReloaded       []*func() // callbacks when Firewalld has been reloaded
 )
 
@@ -70,8 +73,8 @@ func FirewalldInit() error {
 	if connection, err = newConnection(); err != nil {
 		return fmt.Errorf("Failed to connect to D-Bus system bus: %v", err)
 	}
-	firewalldRunning = checkRunning()
-	if !firewalldRunning {
+	FirewalldRunning = checkRunning()
+	if FirewalldRunning {
 		connection.sysconn.Close()
 		connection = nil
 	}
@@ -124,7 +127,7 @@ func (c *Conn) initConnection() error {
 func signalHandler() {
 	for signal := range connection.signal {
 		if strings.Contains(signal.Name, "NameOwnerChanged") {
-			firewalldRunning = checkRunning()
+			FirewalldRunning = checkRunning()
 			dbusConnectionChanged(signal.Body)
 		} else if strings.Contains(signal.Name, "Reloaded") {
 			reloaded()
@@ -185,7 +188,7 @@ func checkRunning() bool {
 	return false
 }
 
-// Passthrough method simply passes args through to iptables/ip6tables
+// Passthrough method simply passes args through to iptables/ip6tables/nft
 func Passthrough(ipv IPV, args ...string) ([]byte, error) {
 	var output string
 	logrus.Debugf("Firewalld passthrough: %s, %s", ipv, args)

--- a/firewalld/firewalld_test.go
+++ b/firewalld/firewalld_test.go
@@ -1,9 +1,12 @@
-package iptables
+package firewalld
 
 import (
 	"net"
 	"strconv"
 	"testing"
+
+	"github.com/docker/libnetwork/firewallapi"
+	"github.com/docker/libnetwork/iptables"
 )
 
 func TestFirewalldInit(t *testing.T) {
@@ -17,10 +20,10 @@ func TestFirewalldInit(t *testing.T) {
 
 func TestReloaded(t *testing.T) {
 	var err error
-	var fwdChain *ChainInfo
+	var fwdChain firewallapi.FirewallChain
 
-	iptable := GetIptable(IPv4)
-	fwdChain, err = iptable.NewChain("FWD", Filter, false)
+	iptable := iptables.GetTable(iptables.IPv4)
+	fwdChain, err = iptable.NewChain("FWD", iptables.Filter, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,12 +41,12 @@ func TestReloaded(t *testing.T) {
 	port := 1234
 	proto := "tcp"
 
-	err = fwdChain.Link(Append, ip1, ip2, port, proto, bridgeName)
+	err = fwdChain.Link(iptables.Append, ip1, ip2, port, proto, bridgeName)
 	if err != nil {
 		t.Fatal(err)
 	} else {
 		// to be re-called again later
-		OnReloaded(func() { fwdChain.Link(Append, ip1, ip2, port, proto, bridgeName) })
+		OnReloaded(func() { fwdChain.Link(iptables.Append, ip1, ip2, port, proto, bridgeName) })
 	}
 
 	rule1 := []string{
@@ -55,7 +58,7 @@ func TestReloaded(t *testing.T) {
 		"--dport", strconv.Itoa(port),
 		"-j", "ACCEPT"}
 
-	if !iptable.Exists(fwdChain.Table, fwdChain.Name, rule1...) {
+	if !iptable.Exists(fwdChain.GetTable(), fwdChain.GetName(), rule1...) {
 		t.Fatal("rule1 does not exist")
 	}
 
@@ -65,7 +68,7 @@ func TestReloaded(t *testing.T) {
 	reloaded()
 
 	// make sure the rules have been recreated
-	if !iptable.Exists(fwdChain.Table, fwdChain.Name, rule1...) {
+	if !iptable.Exists(fwdChain.GetTable(), fwdChain.GetName(), rule1...) {
 		t.Fatal("rule1 hasn't been recreated")
 	}
 }
@@ -77,13 +80,13 @@ func TestPassthrough(t *testing.T) {
 		"--dport", "123",
 		"-j", "ACCEPT"}
 
-	iptable := GetIptable(IPv4)
-	if firewalldRunning {
+	iptable := iptables.GetTable(iptables.IPv4)
+	if FirewalldRunning {
 		_, err := Passthrough(Iptables, append([]string{"-A"}, rule1...)...)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !iptable.Exists(Filter, "INPUT", rule1...) {
+		if !iptable.Exists(iptables.Filter, "INPUT", rule1...) {
 			t.Fatal("rule1 does not exist")
 		}
 	}

--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -3,6 +3,7 @@ package ipam
 import (
 	"fmt"
 	"net"
+	"runtime/debug"
 	"sort"
 	"sync"
 
@@ -444,7 +445,9 @@ func (a *Allocator) getPredefinedPool(as string, ipV6 bool) (*net.IPNet, error) 
 	}
 	aSpace.Unlock()
 
-	return nil, types.NotFoundErrorf("could not find an available, non-overlapping IPv%d address pool among the defaults to assign to the network", v)
+	debug.PrintStack()
+
+	return nil, types.NotFoundErrorf("XXXX could not find an available, non-overlapping IPv%d address pool among the defaults to assign to the network", v)
 }
 
 // RequestAddress returns an address from the specified pool ID

--- a/nftables/conntrack.go
+++ b/nftables/conntrack.go
@@ -1,0 +1,59 @@
+package nftables
+
+import (
+	"errors"
+	"net"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+var (
+	// ErrConntrackNotConfigurable means that conntrack module is not loaded or does not have the netlink module loaded
+	ErrConntrackNotConfigurable = errors.New("conntrack is not available")
+)
+
+// IsConntrackProgrammable returns true if the handle supports the NETLINK_NETFILTER and the base modules are loaded
+func IsConntrackProgrammable(nlh *netlink.Handle) bool {
+	return nlh.SupportsNetlinkFamily(syscall.NETLINK_NETFILTER)
+}
+
+// DeleteConntrackEntries deletes all the conntrack connections on the host for the specified IP
+// Returns the number of flows deleted for IPv4, IPv6 else error
+func DeleteConntrackEntries(nlh *netlink.Handle, ipv4List []net.IP, ipv6List []net.IP) (uint, uint, error) {
+	if !IsConntrackProgrammable(nlh) {
+		return 0, 0, ErrConntrackNotConfigurable
+	}
+
+	var totalIPv4FlowPurged uint
+	for _, ipAddress := range ipv4List {
+		flowPurged, err := purgeConntrackState(nlh, syscall.AF_INET, ipAddress)
+		if err != nil {
+			logrus.Warnf("Failed to delete conntrack state for %s: %v", ipAddress, err)
+			continue
+		}
+		totalIPv4FlowPurged += flowPurged
+	}
+
+	var totalIPv6FlowPurged uint
+	for _, ipAddress := range ipv6List {
+		flowPurged, err := purgeConntrackState(nlh, syscall.AF_INET6, ipAddress)
+		if err != nil {
+			logrus.Warnf("Failed to delete conntrack state for %s: %v", ipAddress, err)
+			continue
+		}
+		totalIPv6FlowPurged += flowPurged
+	}
+
+	logrus.Debugf("DeleteConntrackEntries purged ipv4:%d, ipv6:%d", totalIPv4FlowPurged, totalIPv6FlowPurged)
+	return totalIPv4FlowPurged, totalIPv6FlowPurged, nil
+}
+
+func purgeConntrackState(nlh *netlink.Handle, family netlink.InetFamily, ipAddress net.IP) (uint, error) {
+	filter := &netlink.ConntrackFilter{}
+	// NOTE: doing the flush using the ipAddress is safe because today there cannot be multiple networks with the same subnet
+	// so it will not be possible to flush flows that are of other containers
+	filter.AddIP(netlink.ConntrackNatAnyIP, ipAddress)
+	return nlh.ConntrackDeleteFilter(netlink.ConntrackTable, family, filter)
+}

--- a/nftables/nftables.go
+++ b/nftables/nftables.go
@@ -1,0 +1,680 @@
+package nftables
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/docker/libnetwork/firewallapi"
+	"github.com/docker/libnetwork/firewalld"
+	"github.com/sirupsen/logrus"
+)
+
+// Action signifies the nftable action.
+type Action = firewallapi.Action
+
+// Policy is the default nftable policies
+type Policy = firewallapi.Policy
+
+// Table refers to Nat, Filter or Mangle.
+type Table = firewallapi.Table
+
+// IPVersion refers to IP version, v4 or v6
+type IPVersion = firewallapi.IPVersion
+
+const (
+	// Append appends the rule at the end of the chain.
+	Append Action = "add rule"
+	// Delete deletes the rule from the chain.
+	Delete Action = "delete rule"
+	// Insert inserts the rule at the top of the chain.
+	Insert Action = "insert rule"
+	// Nat table is used for nat translation rules.
+	Nat firewallapi.Table = firewallapi.Nat
+	// Filter table is used for filter rules.
+	Filter firewallapi.Table = firewallapi.Filter
+	// Mangle table is used for mangling the packet.
+	Mangle firewallapi.Table = firewallapi.Mangle
+	// Drop is the default nftables DROP policy
+	Drop Policy = "drop"
+	// Accept is the default nftables ACCEPT policy
+	Accept Policy = "accept"
+	// inet is both version 4 and 6
+	// "ip" and "ip6" can be used to segregate, but unlike iptables
+	// nftable doesn't need to differentiate between binaries, so
+	// this distinction is kept only for compatibility with drivers
+	// ip is version 4
+	IPv4 IPVersion = "ip"
+	// ip6 is version 6
+	IPv6 IPVersion = "ip6"
+)
+
+var (
+	nftablesPath   string
+	bestEffortLock sync.Mutex
+	// ErrNftablesNotFound is returned when the rule is not found.
+	ErrNftablesNotFound = errors.New("Nftables not found")
+	initOnce            sync.Once
+)
+
+type NFTable struct {
+	firewallapi.FirewallTable
+	Version IPVersion
+}
+
+// ChainInfo defines the nftables chain.
+type ChainInfo struct {
+	Name          string
+	Table         Table
+	HairpinMode   bool
+	FirewallTable NFTable
+}
+
+// ChainError is returned to represent errors during nf table operation.
+type ChainError struct {
+	Chain  string
+	Output []byte
+}
+
+func (e ChainError) Error() string {
+	return fmt.Sprintf("Error nftables %s: %s", e.Chain, string(e.Output))
+}
+
+func probe() {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		logrus.Warnf("Failed to find nftables: %v", err)
+		return
+	}
+	if out, err := exec.Command(path, "-n", "list", "table", "nat").CombinedOutput(); err != nil {
+		logrus.Warnf("Running nft -n list table nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+	}
+}
+
+func initFirewalld() {
+	if err := firewalld.FirewalldInit(); err != nil {
+		logrus.Debugf("Fail to initialize firewalld: %v, using raw nftables instead", err)
+	}
+}
+
+func detectNftables() {
+	path, err := exec.LookPath("nft")
+	if err != nil {
+		return
+	}
+	nftablesPath = path
+	if err != nil {
+		logrus.Warnf("Failed to read nftables version: %v", err)
+		return
+	}
+}
+
+func initDependencies() {
+	probe()
+	initFirewalld()
+	detectNftables()
+}
+
+func initCheck() error {
+	initOnce.Do(initDependencies)
+
+	if nftablesPath == "" {
+		return ErrNftablesNotFound
+	}
+	return nil
+}
+
+// GetTable returns an instance of NFTable with specified version
+func GetTable(version IPVersion) firewallapi.FirewallTable {
+	return &NFTable{Version: version}
+}
+
+// NewChain adds a new chain to ip table.
+func (nftable NFTable) NewChain(name string, table Table, hairpinMode bool) (firewallapi.FirewallChain, error) {
+	c := &ChainInfo{
+		Name:          name,
+		Table:         table,
+		HairpinMode:   hairpinMode,
+		FirewallTable: nftable,
+	}
+
+	if string(c.GetTable()) == "" {
+		c.SetTable(Table(firewallapi.Filter))
+	}
+
+	// Add chain if it doesn't exist
+	if _, err := nftable.Raw("-n", "list", "table", string(c.FirewallTable.Version), string(c.GetTable()), c.GetName()); err != nil {
+		if output, err := nftable.raw("add", "chain", string(c.FirewallTable.Version), string(c.GetTable()), c.GetName()); err != nil {
+			return nil, err
+		} else if len(output) != 0 {
+			return nil, fmt.Errorf("Could not create %s/%s/%s chain: %s", c.FirewallTable.Version, c.GetTable(), c.GetName(), output)
+		}
+	}
+	return c, nil
+}
+
+// LoopbackByVersion returns loopback address by version
+func (nftable NFTable) LoopbackByVersion() string {
+	if nftable.Version == IPv6 {
+		return "::1/128"
+	}
+	return "127.0.0.0/8"
+}
+
+// ProgramChain is used to add rules to a chain
+func (nftable NFTable) ProgramChain(c firewallapi.FirewallChain, bridgeName string, hairpinMode, enable bool) error {
+	if c.GetName() == "" {
+		return errors.New("Could not program chain, missing chain name")
+	}
+
+	// Either add or remove the interface from the firewalld zone
+	if firewalld.FirewalldRunning {
+		if enable {
+			if err := firewalld.AddInterfaceFirewalld(bridgeName); err != nil {
+				return err
+			}
+		} else {
+			if err := firewalld.DelInterfaceFirewalld(bridgeName); err != nil {
+				return err
+			}
+		}
+	}
+
+	switch c.GetTable() {
+	case Nat:
+		// daddr type 2 is local
+		preroute := []string{
+			"fib", "daddr",
+			"type", "2",
+			"jump", c.GetName()}
+		if !nftable.Exists(Nat, "prerouting", preroute...) && enable {
+			if err := c.Prerouting(Append, preroute...); err != nil {
+				return fmt.Errorf("Failed to inject %s in prerouting chain: %s", c.GetName(), err)
+			}
+		} else if nftable.Exists(Nat, "prerouting", preroute...) && !enable {
+			if err := c.DeleteRule(nftable.Version, c.GetTable(), "prerouting", preroute...); err != nil {
+				return fmt.Errorf("Failed to remove %s in prerouting chain: %s", c.GetName(), err)
+			}
+		}
+		output := []string{
+			"fib", "daddr",
+			"type", "2",
+			"jump", c.GetName()}
+		if !hairpinMode {
+			output = append([]string{"daddr", "!=", nftable.LoopbackByVersion()}, output...)
+		}
+		if !nftable.Exists(Nat, "output", output...) && enable {
+			if err := c.Output(Append, output...); err != nil {
+				return fmt.Errorf("Failed to inject %s in output chain: %s", c.GetName(), err)
+			}
+		} else if nftable.Exists(Nat, "output", output...) && !enable {
+			if err := c.DeleteRule(nftable.Version, c.GetTable(), "output", output...); err != nil {
+				return fmt.Errorf("Failed to inject %s in output chain: %s", c.GetName(), err)
+			}
+		}
+	case Filter:
+		if bridgeName == "" {
+			return fmt.Errorf("Could not program chain %s/%s, missing bridge name",
+				c.GetTable(), c.GetName())
+		}
+		link := []string{
+			"oifname", bridgeName,
+			"jump", c.GetName()}
+		if !nftable.Exists(Filter, "forward", link...) && enable {
+			insert := append([]string{string(Insert), "forward"}, link...)
+			if output, err := nftable.Raw(insert...); err != nil {
+				return err
+			} else if len(output) != 0 {
+				return fmt.Errorf("Could not create linking rule to %s/%s: %s", c.GetTable(), c.GetName(), output)
+			}
+		} else if nftable.Exists(Filter, "forward", link...) && !enable {
+			if err := c.DeleteRule(nftable.Version, c.GetTable(), "forward", link...); err != nil {
+				return fmt.Errorf("Could not delete linking rule from %s/%s: %s", c.GetTable(), c.GetName(), err)
+			}
+
+		}
+		establish := []string{
+			"oifname", bridgeName,
+			"ct", "state", "related, established",
+			"accept"}
+		if !nftable.Exists(Filter, "forward", establish...) && enable {
+			insert := append([]string{string(Insert), "forward"}, establish...)
+			if output, err := nftable.Raw(insert...); err != nil {
+				return err
+			} else if len(output) != 0 {
+				return fmt.Errorf("Could not create establish rule to %s: %s", c.GetTable(), output)
+			}
+		} else if nftable.Exists(Filter, "forward", establish...) && !enable {
+			if err := c.DeleteRule(nftable.Version, c.GetTable(), "forward", establish...); err != nil {
+				return fmt.Errorf("Could not delete establish rule from %s: %s", c.GetTable(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// RemoveExistingChain removes existing chain from the table.
+func (nftable NFTable) RemoveExistingChain(name string, table Table) error {
+	c := &ChainInfo{
+		Name:          name,
+		Table:         table,
+		FirewallTable: nftable,
+	}
+	if string(c.GetTable()) == "" {
+		c.SetTable(Filter)
+	}
+	return c.Remove()
+}
+
+// Forward adds forwarding rule to 'filter' table and corresponding nat rule to 'nat' table.
+func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr string, destPort int, bridgeName string) error {
+
+	nftable := GetTable(c.FirewallTable.Version)
+	daddr := ip.String()
+	var args []string
+	if ip.IsUnspecified() {
+		// nftables interprets "0.0.0.0" as "0.0.0.0/32", whereas we
+		// want "0.0.0.0/0". "0/0" is correctly interpreted as "any
+		// value" by nftables.
+		args = []string{
+			proto,
+			"dport", strconv.Itoa(port),
+			"dnat",
+			"to", net.JoinHostPort(destAddr, strconv.Itoa(destPort))}
+	} else {
+		args = []string{
+			"ip", "daddr", daddr,
+			proto,
+			"dport", strconv.Itoa(port),
+			"dnat",
+			"to", net.JoinHostPort(destAddr, strconv.Itoa(destPort))}
+	}
+
+	if !c.HairpinMode {
+		args = append([]string{"iifname", "!=", bridgeName}, args...)
+	}
+	if err := nftable.ProgramRule(Nat, c.GetName(), action, args); err != nil {
+		return err
+	}
+
+	if ip.IsUnspecified() {
+		// nftables interprets "0.0.0.0" as "0.0.0.0/32", whereas we
+		// want "0.0.0.0/0". "0/0" is correctly interpreted as "any
+		// value" by nftables.
+		args = []string{
+			"iifname", "!=", bridgeName,
+			"oifname", bridgeName,
+			proto,
+			"dport", strconv.Itoa(port),
+			"accept"}
+	} else {
+		args = []string{
+			"iifname", "!=", bridgeName,
+			"oifname", bridgeName,
+			"ip", "daddr", daddr,
+			proto,
+			"dport", strconv.Itoa(port),
+			"accept"}
+	}
+
+	if err := nftable.ProgramRule(Filter, c.GetName(), action, args); err != nil {
+		return err
+	}
+
+	args = []string{
+		"ip", "saddr", destAddr,
+		"ip", "daddr", destAddr,
+		proto,
+		"dport", strconv.Itoa(port),
+		"masquerade"}
+
+	if err := nftable.ProgramRule(Nat, "postrouting", action, args); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Link adds reciprocal ACCEPT rule for two supplied IP addresses.
+// Traffic is allowed from ip1 to ip2 and vice-versa
+func (c *ChainInfo) Link(action Action, ip1, ip2 net.IP, port int, proto string, bridgeName string) error {
+	nftable := GetTable(c.FirewallTable.Version)
+	// forward
+	args := []string{
+		"iifname", bridgeName,
+		"oifname", bridgeName,
+		"ip", "saddr", ip1.String(),
+		"ip", "daddr", ip2.String(),
+		proto, "dport", strconv.Itoa(port),
+		"accept"}
+
+	if err := nftable.ProgramRule(Filter, c.GetName(), action, args); err != nil {
+		return err
+	}
+	// reverse
+	args = []string{
+		"iifname", bridgeName,
+		"oifname", bridgeName,
+		"ip", "saddr", ip2.String(),
+		"ip", "daddr", ip1.String(),
+		proto, "sport", strconv.Itoa(port),
+		"accept"}
+	return nftable.ProgramRule(Filter, c.GetName(), action, args)
+}
+
+func (c *ChainInfo) DeleteRule(version IPVersion, table Table, chain string, rule ...string) error {
+	chain = strings.ToLower(chain)
+
+	return DeleteRule(version, table, chain, rule...)
+}
+
+func (nftable NFTable) DeleteRule(version IPVersion, table Table, chain string, rule ...string) error {
+	chain = strings.ToLower(chain)
+
+	return DeleteRule(version, table, chain, rule...)
+}
+
+func DeleteRule(version IPVersion, table Table, chain string, rule ...string) error {
+	chain = strings.ToLower(chain)
+
+	bestEffortLock.Lock()
+	defer bestEffortLock.Unlock()
+
+	path := nftablesPath
+	commandName := "nft"
+
+	findRuleArgs := []string{"-n", "-a", "list", "chain", string(version), string(table), chain}
+	handleMatcher := regexp.MustCompile(`#\shandle\s(\d+)`)
+	var handle string
+
+	findRule, err := exec.Command(path, findRuleArgs...).CombinedOutput()
+
+	ruleStr := strings.Split(string(findRule), "\n")
+
+	for _, d := range ruleStr {
+		if strings.Contains(d, strings.Join(rule, " ")) {
+			handle = handleMatcher.FindStringSubmatch(d)[1]
+		}
+	}
+
+	args := []string{string(Delete), string(version), string(table), chain, "handle", handle}
+
+	output, err := exec.Command(path, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("nft failed: %s %v: %s (%s)", commandName, strings.Join(args, " "), output, err)
+	}
+
+	return nil
+}
+
+// ProgramRule adds the rule specified by args only if the
+// rule is not already present in the chain. Reciprocally,
+// it removes the rule only if present.
+func (nftable NFTable) ProgramRule(table Table, chain string, action Action, args []string) error {
+	chain = strings.ToLower(chain)
+
+	if nftable.Exists(table, chain, args...) != (action == Delete) {
+		return nil
+	}
+	return nftable.RawCombinedOutput(append([]string{string(action), string(nftable.Version), string(table), chain}, args...)...)
+}
+
+// Prerouting adds linking rule to nat/PREROUTING chain.
+func (c *ChainInfo) Prerouting(action Action, args ...string) error {
+	nftable := GetTable(c.FirewallTable.Version)
+	a := []string{string(action), string(c.FirewallTable.Version), string(Nat), "prerouting"}
+	if len(args) > 0 {
+		a = append(a, args...)
+	}
+	if output, err := nftable.Raw(a...); err != nil {
+		return err
+	} else if len(output) != 0 {
+		return ChainError{Chain: "prerouting", Output: output}
+	}
+	return nil
+}
+
+// Output adds linking rule to an OUTPUT chain.
+func (c *ChainInfo) Output(action Action, args ...string) error {
+	nftable := GetTable(c.FirewallTable.Version)
+	a := []string{string(action), string(c.FirewallTable.Version), string(c.GetTable()), "output"}
+	if len(args) > 0 {
+		a = append(a, args...)
+	}
+	if output, err := nftable.Raw(a...); err != nil {
+		return err
+	} else if len(output) != 0 {
+		return ChainError{Chain: "output", Output: output}
+	}
+	return nil
+}
+
+// Remove removes the chain.
+func (c *ChainInfo) Remove() error {
+	nftable := GetTable(c.FirewallTable.Version)
+
+	nftable.Raw("flush", "chain", string(c.FirewallTable.Version), c.GetName())
+	nftable.Raw("delete", "chain", string(c.FirewallTable.Version), string(c.GetTable()), c.GetName())
+	return nil
+}
+
+// Exists checks if a rule exists
+func (nftable NFTable) Exists(table Table, chain string, rule ...string) bool {
+	chain = strings.ToLower(chain)
+
+	return nftable.exists(false, table, chain, rule...)
+}
+
+// ExistsNative behaves as Exists with the difference it
+// will always invoke `nft` binary.
+func (nftable NFTable) ExistsNative(table Table, chain string, rule ...string) bool {
+	chain = strings.ToLower(chain)
+
+	return nftable.exists(true, table, chain, rule...)
+}
+
+func (nftable NFTable) exists(native bool, table Table, chain string, rule ...string) bool {
+	chain = strings.ToLower(chain)
+
+	f := nftable.Raw
+	if native {
+		f = nftable.raw
+	}
+
+	if string(table) == "" {
+		table = Filter
+	}
+
+	if err := initCheck(); err != nil {
+		// The exists() signature does not allow us to return an error, but at least
+		// we can skip the (likely invalid) exec invocation.
+		return false
+	}
+
+	findRuleArgs := []string{"-n", "-a", "list", "chain", string(nftable.Version), string(table), chain}
+	handleMatcher := regexp.MustCompile(`#\shandle\s(\d+)`)
+	var handle string
+
+	findRule, _ := f(findRuleArgs...)
+
+	ruleStr := strings.Split(string(findRule), "\n")
+
+	for _, d := range ruleStr {
+		if strings.Contains(d, strings.Join(rule, " ")) {
+			handle = handleMatcher.FindStringSubmatch(d)[1]
+		}
+	}
+	return handle == ""
+}
+
+func (nftable NFTable) existsRaw(table Table, chain string, rule ...string) bool {
+	chain = strings.ToLower(chain)
+
+	path := nftablesPath
+	if nftable.Version == IPv6 {
+		// Do somethng here
+	}
+	ruleString := fmt.Sprintf("%s %s\n", chain, strings.Join(rule, " "))
+	existingRules, _ := exec.Command(path, "-t", string(table), "-S", chain).Output()
+
+	return strings.Contains(string(existingRules), ruleString)
+}
+
+// Raw calls 'nft' system command, passing supplied arguments.
+func (nftable NFTable) Raw(args ...string) ([]byte, error) {
+	var firewalldTable firewalld.IPV
+	if nftable.Version == IPv4 {
+		firewalldTable = firewalld.Iptables
+	} else {
+		firewalldTable = firewalld.IP6Tables
+	}
+	if firewalld.FirewalldRunning {
+		output, err := firewalld.Passthrough(firewalldTable, args...)
+		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
+			return output, err
+		}
+	}
+	return nftable.raw(args...)
+}
+
+func (nftable NFTable) raw(args ...string) ([]byte, error) {
+	if err := initCheck(); err != nil {
+		return nil, err
+	}
+	bestEffortLock.Lock()
+	defer bestEffortLock.Unlock()
+
+	path := nftablesPath
+	commandName := "nft"
+
+	output, err := exec.Command(path, args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("nft failed: %s %v: %s (%s)", commandName, strings.Join(args, " "), output, err)
+	}
+
+	return output, err
+}
+
+// RawCombinedOutput internally calls the Raw function and returns a non nil
+// error if Raw returned a non nil error or a non empty output
+func (nftable NFTable) RawCombinedOutput(args ...string) error {
+	if output, err := nftable.Raw(args...); err != nil || len(output) != 0 {
+		return fmt.Errorf("%s (%v)", string(output), err)
+	}
+	return nil
+}
+
+// RawCombinedOutputNative behave as RawCombinedOutput with the difference it
+// will always invoke `nft` binary
+func (nftable NFTable) RawCombinedOutputNative(args ...string) error {
+	if output, err := nftable.raw(args...); err != nil || len(output) != 0 {
+		return fmt.Errorf("%s (%v)", string(output), err)
+	}
+	return nil
+}
+
+// ExistChain checks if a chain exists
+func (nftable NFTable) ExistChain(chain string, table Table) bool {
+	chain = strings.ToLower(chain)
+
+	if _, err := nftable.Raw("-n", "list", "table", string(nftable.Version), string(table)); err == nil {
+		return true
+	}
+	return false
+}
+
+// GetVersion reads the nft version numbers during initialization
+func GetVersion() (major, minor, micro int, err error) {
+	out, err := exec.Command(nftablesPath, "--version").CombinedOutput()
+	if err == nil {
+		major, minor, micro = parseVersionNumbers(string(out))
+	}
+	return
+}
+
+// SetDefaultPolicy sets the passed default policy for the table/chain
+func (nftable NFTable) SetDefaultPolicy(table Table, chain string, policy Policy) error {
+	chain = strings.ToLower(chain)
+	if err := nftable.RawCombinedOutput(chain, string(nftable.Version), string(table),
+		fmt.Sprintf("'{ policy %s ; }'", strings.ToLower(string(policy)))); err != nil {
+		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
+	}
+	return nil
+}
+
+func parseVersionNumbers(input string) (major, minor, micro int) {
+	re := regexp.MustCompile(`v\d*.\d*.\d*`)
+	line := re.FindString(input)
+	fmt.Sscanf(line, "v%d.%d.%d", &major, &minor, &micro)
+	return
+}
+
+// AddReturnRule adds a return rule for the chain in the filter table
+func (nftable NFTable) AddReturnRule(chain string) error {
+	chain = strings.ToLower(chain)
+	var (
+		table = Filter
+		args  = []string{"return"}
+	)
+
+	if nftable.Exists(table, chain, args...) {
+		return nil
+	}
+
+	err := nftable.RawCombinedOutput(append([]string{string(Append), string(nftable.Version), string(table), chain}, args...)...)
+	if err != nil {
+		return fmt.Errorf("unable to add return rule in %s chain: %s", chain, err.Error())
+	}
+
+	return nil
+}
+
+// EnsureJumpRule ensures the jump rule is on top
+func (nftable NFTable) EnsureJumpRule(fromChain, toChain string) error {
+	fromChain = strings.ToLower(fromChain)
+	toChain = strings.ToLower(toChain)
+
+	var (
+		table = Filter
+		args  = []string{"jump", toChain}
+	)
+
+	if nftable.Exists(table, fromChain, args...) {
+		err := nftable.DeleteRule(nftable.Version, "filter", fromChain, args...)
+		if err != nil {
+			return fmt.Errorf("unable to remove jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+		}
+	}
+
+	err := nftable.RawCombinedOutput(append([]string{"insert", "rule", "ip", "filter", fromChain}, args...)...)
+	if err != nil {
+		return fmt.Errorf("unable to insert jump to %s rule in %s chain: %s", toChain, fromChain, err.Error())
+	}
+
+	return nil
+}
+
+func (c *ChainInfo) GetName() string {
+	return c.GetName()
+}
+
+func (c *ChainInfo) GetTable() Table {
+	return c.GetTable()
+}
+
+func (c *ChainInfo) SetTable(t Table) {
+	c.Table = t
+}
+
+func (c *ChainInfo) GetHairpinMode() bool {
+	return c.HairpinMode
+}
+
+func (c *ChainInfo) GetFirewallTable() firewallapi.FirewallTable {
+	return c.FirewallTable
+}

--- a/portmapper/mapper_linux.go
+++ b/portmapper/mapper_linux.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/docker/libnetwork/firewallapi"
 	"github.com/docker/libnetwork/iptables"
 	"github.com/docker/libnetwork/portallocator"
 )
@@ -19,11 +20,11 @@ type PortMapper struct {
 	proxyPath string
 
 	Allocator *portallocator.PortAllocator
-	chain     *iptables.ChainInfo
+	chain     firewallapi.FirewallChain
 }
 
 // SetIptablesChain sets the specified chain into portmapper
-func (pm *PortMapper) SetIptablesChain(c *iptables.ChainInfo, bridgeName string) {
+func (pm *PortMapper) SetFirewallTablesChain(c firewallapi.FirewallChain, bridgeName string) {
 	pm.chain = c
 	pm.bridgeName = bridgeName
 }

--- a/portmapper/mapper_test.go
+++ b/portmapper/mapper_test.go
@@ -25,7 +25,7 @@ func TestSetIptablesChain(t *testing.T) {
 		t.Fatal("chain should be nil at init")
 	}
 
-	pm.SetIptablesChain(c, "lo")
+	pm.SetFirewallTablesChain(c, "lo")
 	if pm.chain == nil {
 		t.Fatal("chain should not be nil after set")
 	}

--- a/resolver_unix.go
+++ b/resolver_unix.go
@@ -58,7 +58,7 @@ func reexecSetupResolver() {
 	}
 
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	// insert outputChain and postroutingchain
 	err = iptable.RawCombinedOutputNative("-t", "nat", "-C", "OUTPUT", "-d", resolverIP, "-j", outputChain)

--- a/service_linux.go
+++ b/service_linux.go
@@ -304,7 +304,7 @@ func filterPortConfigs(ingressPorts []*PortConfig, isDelete bool) []*PortConfig 
 
 func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) error {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 
 	addDelOpt := "-I"
 	rollbackAddDelOpt := "-D"
@@ -466,7 +466,7 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 // from local bridge networks and docker_gwbridge (ie:taks on other swarm networks)
 func arrangeIngressFilterRule() {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	if iptable.ExistChain(ingressChain, iptables.Filter) {
 		if iptable.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
 			if err := iptable.RawCombinedOutput("-D", "FORWARD", "-j", ingressChain); err != nil {
@@ -613,7 +613,7 @@ func invokeFWMarker(path string, vip net.IP, fwMark uint32, ingressPorts []*Port
 // Firewall marker reexec function.
 func fwMarker() {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -720,7 +720,7 @@ func addRedirectRules(path string, eIP *net.IPNet, ingressPorts []*PortConfig) e
 // Redirector reexec function.
 func redirector() {
 	// TODO IPv6 support
-	iptable := iptables.GetIptable(iptables.IPv4)
+	iptable := iptables.GetTable(iptables.IPv4)
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 


### PR DESCRIPTION
With the release of EL8, nftables has become the default firewall
implementation on minimal installs of CentOS/OEL/RHEL8. While an
iptables driver is available (both in libnetwork and a mapper in
nftables itself), this is not guaranteed to be present. firewalld
pulls in iptables, but firewalld itself does not yet support raw
commands to nftables.

iptables calls were heavily enmeshed in libnetwork. It was
necessary to create a relatively large interface in order to
break the coupling to native iptables implementations, but this
offers the flexibility to support or add other drivers in the
future

Remaining changes are needed to:

    drivers/bridge/link.go
    drivers/bridge/setup_tables.go
    drivers/overlay/encryption.go
    drivers/overlay/filter.go
    resolver_unix.go
    service_linux.go

But all are sall in scope compared to this, and are translating
remaining raw iptables rules to nftables and adding additional
interface methods/methods for re-used logic