### PR TITLE
Use hostIP to decide on Portmapper version

### DIFF
--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -139,7 +139,7 @@ func (n *bridgeNetwork) allocatePort(bnd *types.PortBinding, ulPxyEnabled bool) 
 
 	portmapper := n.portMapper
 
-	if bnd.IP.To4() == nil {
+	if bnd.HostIP.To4() == nil {
 		portmapper = n.portMapperV6
 	}
 


### PR DESCRIPTION
Use HostIP to decide which portmapper object to store the binding
in consistently in the allocate and release method (https://github.com/moby/libnetwork/blob/448016ef11309bd67541dcf4d72f1f5b7de94862/drivers/bridge/port_mapping.go#L208)

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>