### PR TITLE
ipvlan: support l3s mode

### DIFF
--- a/drivers/ipvlan/ipvlan.go
+++ b/drivers/ipvlan/ipvlan.go
@@ -18,6 +18,7 @@ const (
 	ipvlanType          = "ipvlan" // driver type name
 	modeL2              = "l2"     // ipvlan mode l2 is the default
 	modeL3              = "l3"     // ipvlan L3 mode
+	modeL3S             = "l3s"    // ipvlan L3S mode
 	parentOpt           = "parent" // parent interface -o parent
 	modeOpt             = "_mode"  // ipvlan mode ux opt suffix
 )

--- a/drivers/ipvlan/ipvlan_joinleave.go
+++ b/drivers/ipvlan/ipvlan_joinleave.go
@@ -51,7 +51,8 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return fmt.Errorf("could not find endpoint with id %s", eid)
 	}
 	if !n.config.Internal {
-		if n.config.IpvlanMode == modeL3 {
+		switch n.config.IpvlanMode {
+		case modeL3, modeL3S:
 			// disable gateway services to add a default gw using dev eth0 only
 			jinfo.DisableGatewayService()
 			defaultRoute, err := ifaceGateway(defaultV4RouteCidr)
@@ -59,7 +60,7 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 				return err
 			}
 			if err := jinfo.AddStaticRoute(defaultRoute.Destination, defaultRoute.RouteType, defaultRoute.NextHop); err != nil {
-				return fmt.Errorf("failed to set an ipvlan l3 mode ipv4 default gateway: %v", err)
+				return fmt.Errorf("failed to set an ipvlan l3/l3s mode ipv4 default gateway: %v", err)
 			}
 			logrus.Debugf("Ipvlan Endpoint Joined with IPv4_Addr: %s, Ipvlan_Mode: %s, Parent: %s",
 				ep.addr.IP.String(), n.config.IpvlanMode, n.config.Parent)
@@ -70,13 +71,12 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 					return err
 				}
 				if err = jinfo.AddStaticRoute(default6Route.Destination, default6Route.RouteType, default6Route.NextHop); err != nil {
-					return fmt.Errorf("failed to set an ipvlan l3 mode ipv6 default gateway: %v", err)
+					return fmt.Errorf("failed to set an ipvlan l3/l3s mode ipv6 default gateway: %v", err)
 				}
 				logrus.Debugf("Ipvlan Endpoint Joined with IPv6_Addr: %s, Ipvlan_Mode: %s, Parent: %s",
 					ep.addrv6.IP.String(), n.config.IpvlanMode, n.config.Parent)
 			}
-		}
-		if n.config.IpvlanMode == modeL2 {
+		case modeL2:
 			// parse and correlate the endpoint v4 address with the available v4 subnets
 			if len(n.config.Ipv4Subnets) > 0 {
 				s := n.getSubnetforIPv4(ep.addr)

--- a/drivers/ipvlan/ipvlan_network.go
+++ b/drivers/ipvlan/ipvlan_network.go
@@ -47,6 +47,8 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 		config.IpvlanMode = modeL2
 	case modeL3:
 		config.IpvlanMode = modeL3
+	case modeL3S:
+		config.IpvlanMode = modeL3S
 	default:
 		return fmt.Errorf("requested ipvlan mode '%s' is not valid, 'l2' mode is the ipvlan driver default", config.IpvlanMode)
 	}

--- a/drivers/ipvlan/ipvlan_setup.go
+++ b/drivers/ipvlan/ipvlan_setup.go
@@ -55,6 +55,8 @@ func setIPVlanMode(mode string) (netlink.IPVlanMode, error) {
 		return netlink.IPVLAN_MODE_L2, nil
 	case modeL3:
 		return netlink.IPVLAN_MODE_L3, nil
+	case modeL3S:
+		return netlink.IPVLAN_MODE_L3S, nil
 	default:
 		return 0, fmt.Errorf("Unknown ipvlan mode: %s", mode)
 	}

--- a/drivers/ipvlan/ipvlan_setup_test.go
+++ b/drivers/ipvlan/ipvlan_setup_test.go
@@ -68,6 +68,14 @@ func TestSetIPVlanMode(t *testing.T) {
 	if mode != netlink.IPVLAN_MODE_L3 {
 		t.Fatalf("expected %d got %d", netlink.IPVLAN_MODE_L3, mode)
 	}
+	// test ipvlan l3s mode
+	mode, err = setIPVlanMode(modeL3S)
+	if err != nil {
+		t.Fatalf("error parsing %v vlan mode: %v", mode, err)
+	}
+	if mode != netlink.IPVLAN_MODE_L3S {
+		t.Fatalf("expected %d got %d", netlink.IPVLAN_MODE_L3S, mode)
+	}
 	// test invalid mode
 	mode, err = setIPVlanMode("foo")
 	if err == nil {


### PR DESCRIPTION
ipvlan l3s mode was introduced in https://github.com/torvalds/linux/commit/8ddda65315f08b1273095edc1afab4872ea22fe5, available since Linux v4.9

According to Documentation/networking/ipvlan.txt:
> This is very similar to the L3 mode except that iptables (conn-tracking) works in this mode and hence it is L3-symmetric (L3s). This will have slightly less performance but that shouldn’t matter since you are choosing this mode over plain-L3 mode to make conn-tracking work.