### PR TITLE
Fix HNS policylist error "network not found" during network removal 

### DIFF
--- a/network.go
+++ b/network.go
@@ -1062,13 +1062,6 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 		goto removeFromStore
 	}
 
-	if err = n.deleteNetwork(); err != nil {
-		if !force {
-			return err
-		}
-		logrus.Debugf("driver failed to delete stale network %s (%s): %v", n.Name(), n.ID(), err)
-	}
-
 	n.ipamRelease()
 	if err = c.updateToStore(n); err != nil {
 		logrus.Warnf("Failed to update store after ipam release for network %s (%s): %v", n.Name(), n.ID(), err)
@@ -1089,8 +1082,17 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	c.cleanupServiceDiscovery(n.ID())
 
 	// Cleanup the load balancer. On Windows this call is required
-	// to remove remote loadbalancers in VFP.
+	// to remove remote loadbalancers in VFP, and must be performed before
+	// dataplane network deletion.
 	c.cleanupServiceBindings(n.ID())
+
+	// Delete the network from the dataplane
+	if err = n.deleteNetwork(); err != nil {
+		if !force {
+			return err
+		}
+		logrus.Debugf("driver failed to delete stale network %s (%s): %v", n.Name(), n.ID(), err)
+	}
 
 removeFromStore:
 	// deleteFromStore performs an atomic delete operation and the

--- a/network.go
+++ b/network.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -1084,7 +1085,9 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	// Cleanup the load balancer. On Windows this call is required
 	// to remove remote loadbalancers in VFP, and must be performed before
 	// dataplane network deletion.
-	c.cleanupServiceBindings(n.ID())
+	if runtime.GOOS == "windows" {
+		c.cleanupServiceBindings(n.ID())
+	}
 
 	// Delete the network from the dataplane
 	if err = n.deleteNetwork(); err != nil {

--- a/service_common.go
+++ b/service_common.go
@@ -368,12 +368,15 @@ func (c *controller) rmServiceBinding(svcName, svcID, nID, eID, containerName st
 	// Remove loadbalancer service(if needed) and backend in all
 	// sandboxes in the network only if the vip is valid.
 	if entries == 0 {
-		// The network may well have been deleted before the last
-		// of the service bindings.  That's ok on Linux because
-		// removing the network sandbox implicitly removes the
-		// backend service bindings.  Windows VFP cleanup requires
-		// calling cleanupServiceBindings on the network prior to
-		// deleting the network, performed by network.delete.
+		// The network may well have been deleted from the store (and
+		// dataplane) before the last of the service bindings.  On Linux that's
+		// ok because removing the network sandbox from the dataplane
+		// implicitly cleans up all related dataplane state.
+		// On the Windows dataplane, VFP policylists must be removed
+		// independently of the network, and they must be removed before the HNS
+		// network. Otherwise, policylist removal fails with "network not
+		// found." On Windows cleanupServiceBindings must be called prior to
+		// removing the network from the store or dataplane.
 		n, err := c.NetworkByID(nID)
 		if err == nil {
 			n.(*network).rmLBBackend(ip, lb, rmService, fullRemove)

--- a/service_windows.go
+++ b/service_windows.go
@@ -139,12 +139,16 @@ func (n *network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 
 			if policyLists, ok := lbPolicylistMap[lb]; ok {
 				if policyLists.ilb != nil {
-					policyLists.ilb.Delete()
+					if _, err := policyLists.ilb.Delete(); err != nil {
+						logrus.Errorf("Failed to remove HNS ILB policylist %s: %s", policyLists.ilb.ID, err)
+					}
 					policyLists.ilb = nil
 				}
 
 				if policyLists.elb != nil {
-					policyLists.elb.Delete()
+					if _, err := policyLists.elb.Delete(); err != nil {
+						logrus.Errorf("Failed to remove HNS ELB policylist %s: %s", policyLists.elb.ID, err)
+					}
 					policyLists.elb = nil
 				}
 				delete(lbPolicylistMap, lb)


### PR DESCRIPTION
Removal of PolicyLists from Windows VFP must be performed prior to removing the corresponding HNS network. Otherwise PolicyList removal fails with HNS error `"The network was not found."`  

This ordering requirement was introduced to Windows Server 2019 in an update some time in 2020.  Have reached out to Microsoft to request additional context with respect to what OS version(s) in the change was shipped with and the rationale for the change.

Accommodate the OS sequencing requirement by delaying network deletion until after cleaning up service bindings.

This PR also:
* Introduces error logging for the affected HNS calls.
* Provides a performance improvement to Linux overlay network cleanup by making explicit service loadbalancer dataplane cleanup logic conditional to Windows (where it is required).   On Linux, the analogous ipvs dataplane cleanup occurs implicitly with the deletion of the loadbalancer net namespace.
---
Opening as draft to take a look at the following kv error I'm seeing during deletion on Windows. Am also seeing this on 55e924b8a84231a065879156c0de95aefc5f5435 from bump_19.03, so it's likely not related to this PR.

```
2/3/2021 11:04:10 PM Error (Unable to complete atomic operation, key modified) deleting object [endpoint qyuvcy6qzwnsj09ybf9cvs19h c29da54656238a07de515f732e424d9f72e0b466bd83ff0b622ad632cdc2239d], retrying...
```

Mirantis Ref: FIELD-3310