### PR TITLE
Make the IP allocator handle IPv4 networks that don't have network/broadcast addresses.

### DIFF
--- a/ipam/allocator.go
+++ b/ipam/allocator.go
@@ -353,12 +353,15 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 		return err
 	}
 
-	// Do not let network identifier address be reserved
-	// Do the same for IPv6 so that bridge ip starts with XXXX...::1
-	h.Set(0)
+	// Pre-reserve the network address on IPv4 networks large
+	// enough to have one (i.e., /31s and smaller).
+	if !(ipVer == v4 && numAddresses <= 2) {
+		h.Set(0)
+	}
 
-	// Do not let broadcast address be reserved
-	if ipVer == v4 {
+	// Pre-reserve the broadcast address on IPv4 networks large
+	// enough to have one (i.e., anything /31s and smaller).
+	if ipVer == v4 && numAddresses > 2 {
 		h.Set(numAddresses - 1)
 	}
 

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -1054,6 +1054,72 @@ func TestOverlappingRequests(t *testing.T) {
 	}
 }
 
+func TestUnusualSubnets(t *testing.T) {
+
+	subnet := "192.168.0.2/31"
+
+	outsideTheRangeAddresses := []struct {
+		address string
+	}{
+		{"192.168.0.1"},
+		{"192.168.0.4"},
+		{"192.168.0.100"},
+	}
+
+	expectedAddresses := []struct {
+		address string
+	}{
+		{"192.168.0.2"},
+		{"192.168.0.3"},
+	}
+
+	for _, store := range []bool{false, true} {
+
+		allocator, err := getAllocator(store)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		//
+		// IPv4 /31 blocks.  See RFC 3021.
+		//
+
+		pool, _, _, err := allocator.RequestPool(localAddressSpace, subnet, "", nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Outside-the-range
+
+		for _, outside := range outsideTheRangeAddresses {
+			_, _, errx := allocator.RequestAddress(pool, net.ParseIP(outside.address), nil)
+			if errx != ipamapi.ErrIPOutOfRange {
+				t.Fatalf("Address %s failed to throw expected error: %s", outside.address, errx.Error())
+			}
+		}
+
+		// Should get just these two IPs followed by exhaustion on the next request
+
+		for _, expected := range expectedAddresses {
+			got, _, errx := allocator.RequestAddress(pool, nil, nil)
+			if errx != nil {
+				t.Fatalf("Failed to obtain the address: %s", errx.Error())
+			}
+			expectedIP := net.ParseIP(expected.address)
+			gotIP := got.IP
+			if !gotIP.Equal(expectedIP) {
+				t.Fatalf("Failed to obtain sequentialaddress. Expected: %s, Got: %s", expectedIP, gotIP)
+			}
+		}
+
+		_, _, err = allocator.RequestAddress(pool, nil, nil)
+		if err != ipamapi.ErrNoAvailableIPs {
+			t.Fatal("Did not get expected error when pool is exhausted.")
+		}
+
+	}
+}
+
 func TestRelease(t *testing.T) {
 	var (
 		subnet = "192.168.0.0/23"


### PR DESCRIPTION
When creating a new network, IPAM's address allocator attempts to reserve the network and broadcast addresses on IPv4 networks of all sizes.  For RFC 3021 point-to-point networks (IPv4 /31s), this consumes both available addresses and renders any attempt to allocate an address from the block unsuccessful.  See https://github.com/moby/moby/issues/32444.

This change prevents those reservations from taking place on IPv4 networks having two or fewer addresses (i.e., /31s and /32s) while retaining the existing behavior for larger IPv4 blocks and all IPv6 blocks.

Some notes:

 * The modified code is being run successfully in my lab on containers with networks that exercise all of the code paths in the change.  (March 19:  The patched version is being rolled out to production systems.)

 * I wrote additional unit tests which compile, but I'm not getting a warm fuzzy that they're being executed during the build.

* Because this change applies to /32s as well as /31s, it should resolve #2249 as well.  This was verified to the extent that `docker network create --driver bridge --subnet 10.200.1.0/32 --ip-range 10.200.1.0/32 test-32` works but hasn't been tested beyond that.

 * Go is not one of my primary languages, so if there's anything non-idiomatic, please feel free to suggest changes. 
 