### PR TITLE
fix port forwarding with ipv6.disable=1

### DIFF
--- a/drivers/bridge/port_mapping.go
+++ b/drivers/bridge/port_mapping.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/docker/libnetwork/types"
 	"github.com/ishidawataru/sctp"
@@ -48,6 +49,13 @@ func (n *bridgeNetwork) allocatePortsInternal(bindings []types.PortBinding, cont
 				return nil, err
 			}
 			bs = append(bs, bIPv4)
+		}
+
+		// skip adding implicit v6 addr, when the kernel was booted with `ipv6.disable=1`
+		// https://github.com/moby/moby/issues/42288
+		isV6Binding := c.HostIP != nil && c.HostIP.To4() == nil
+		if !isV6Binding && !IsV6Listenable() {
+			continue
 		}
 
 		// Allocate IPv6 Port mappings
@@ -210,4 +218,27 @@ func (n *bridgeNetwork) releasePort(bnd types.PortBinding) error {
 	}
 
 	return portmapper.Unmap(host)
+}
+
+var (
+	v6ListenableCached bool
+	v6ListenableOnce   sync.Once
+)
+
+// IsV6Listenable returns true when `[::1]:0` is listenable.
+// IsV6Listenable returns false mostly when the kernel was booted with `ipv6.disable=1` option.
+func IsV6Listenable() bool {
+	v6ListenableOnce.Do(func() {
+		ln, err := net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			// When the kernel was booted with `ipv6.disable=1`,
+			// we get err "listen tcp6 [::1]:0: socket: address family not supported by protocol"
+			// https://github.com/moby/moby/issues/42288
+			logrus.Debugf("port_mapping: v6Listenable=false (%v)", err)
+		} else {
+			v6ListenableCached = true
+			ln.Close()
+		}
+	})
+	return v6ListenableCached
 }

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/drivers/bridge"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/options"
@@ -199,7 +200,11 @@ func TestBridge(t *testing.T) {
 	if !ok {
 		t.Fatalf("Unexpected format for port mapping in endpoint operational data")
 	}
-	if len(pm) != 10 {
+	expectedLen := 10
+	if !bridge.IsV6Listenable() {
+		expectedLen = 5
+	}
+	if len(pm) != expectedLen {
 		t.Fatalf("Incomplete data for port mapping in endpoint operational data: %d", len(pm))
 	}
 }


### PR DESCRIPTION
Make `docker run -p 80:80` functional again on environments with kernel boot parameter `ipv6.disable=1`.

Fix moby/moby#42288

--- 
Tested on Ubuntu 21.04.

Previously, `docker run -p 80:80` with `ipv6.disable=1` was failing with an error: 
```docker: Error response from daemon: driver failed programming external connectivity on endpoint naughty_moore (038e9ed4b5ea77e1c52462d6d04ad001fbad9beb185a6511aadc217c8a271608): Error starting userland proxy: listen tcp6 [::]:80: socket: address family not supported by protocol.```