### PR TITLE
update maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,11 +11,20 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
+			"akihirosuda",
 			"arkodg",
+			"corhere",
+			"cpuguy83",
 			"euanh",
 			"fcrisciani",
 			"mavenugo",
+			"neersighted",
+			"rumpl",
 			"selansen",
+			"thajeztah",
+			"tianon",
+			"tonistiigi",
+			"vvoland",
 		]
 
 [people]
@@ -26,10 +35,25 @@
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
 
+	[people.akihirosuda]
+	Name = "Akihiro Suda"
+	Email = "akihiro.suda.cz@hco.ntt.co.jp"
+	GitHub = "AkihiroSuda"
+
 	[people.arkodg]
 	Name = "Arko Dasgupta"
 	Email = "arko.dasgupta@docker.com"
 	GitHub = "arkodg"
+
+	[people.corhere]
+	Name = "Cory Snider"
+	Email = "csnider@mirantis.com"
+	GitHub = "corhere"
+
+	[people.cpuguy83]
+	Name = "Brian Goff"
+	Email = "cpuguy83@gmail.com"
+	GitHub = "cpuguy83"
 
 	[people.euanh]
 	Name = "Euan Harris"
@@ -46,7 +70,32 @@
 	Email = "madhu@docker.com"
 	GitHub = "mavenugo"
 
+	[people.rumpl]
+	Name = "Djordje Lukic"
+	Email = "djordje.lukic@docker.com"
+	GitHub = "rumpl"
+
 	[people.selansen]
 	Name = "Elangovan Sivanandam"
 	Email = "elango.siva@docker.com"
 	GitHub = "selansen"
+
+	[people.thajeztah]
+	Name = "Sebastiaan van Stijn"
+	Email = "github@gone.nl"
+	GitHub = "thaJeztah"
+
+	[people.tianon]
+	Name = "Tianon Gravi"
+	Email = "admwiggin@gmail.com"
+	GitHub = "tianon"
+
+	[people.tonistiigi]
+	Name = "Tõnis Tiigi"
+	Email = "tonis@docker.com"
+	GitHub = "tonistiigi"
+
+	[people.vvoland]
+	Name = "Paweł Gronowski"
+	Email = "pawel.gronowski@docker.com"
+	GitHub = "vvoland"


### PR DESCRIPTION
The current list of maintainers is quite outdated, and we plan to integrate libnetwork into the main Moby repository.

Before doing this, we may still need to review and merge fixes that are pending in this repository (as well as maintain a branch for the 20.10 release until it reaches EOL).

This patch adds some of the (currently) active maintainers of the moby project to the maintainers list.
