### PR TITLE
Apply peformance tuning to new sandboxes also

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -1174,7 +1174,14 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 	}
 
 	if sb.osSbox != nil {
-		// Apply operating specific knobs on the load balancer sandbox
+		err := sb.osSbox.InvokeFunc(func() {
+			sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+		})
+
+		if err != nil {
+			logrus.Errorf("Failed to apply performance tuning sysctls the sandbox: %v", err)
+		}
+		// Keep this just so performance is not changed
 		sb.osSbox.ApplyOSTweaks(sb.oslTypes)
 	}
 

--- a/osl/namespace_linux.go
+++ b/osl/namespace_linux.go
@@ -48,6 +48,17 @@ var (
 		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L144:1
 		"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
 	}
+	ingressConfig = map[string]*kernel.OSValue{
+		// disables any special handling on port reuse of existing IPVS connection table entries
+		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L25:1
+		"net.ipv4.vs.conn_reuse_mode": {Value: "0", CheckFn: nil},
+		// expires connection from the IPVS connection table when the backend is not available
+		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L126:1
+		"net.ipv4.vs.expire_nodest_conn": {Value: "1", CheckFn: nil},
+		// expires persistent connections to destination servers with weights set to 0
+		// more info: https://github.com/torvalds/linux/blob/master/Documentation/networking/ipvs-sysctl.txt#L144:1
+		"net.ipv4.vs.expire_quiescent_template": {Value: "1", CheckFn: nil},
+	}
 )
 
 // The networkNamespace type is the linux implementation of the Sandbox
@@ -688,6 +699,9 @@ func (n *networkNamespace) ApplyOSTweaks(types []SandboxType) {
 		switch t {
 		case SandboxTypeLoadBalancer:
 			kernel.ApplyOSTweaks(loadBalancerConfig)
+		}
+		case SandboxTypeIngress:
+			kernel.ApplyOSTweaks(ingressConfig)
 		}
 	}
 }


### PR DESCRIPTION
Previously, values for `expire_quiescent_template`, `conn_reuse_mode`,
and `expire_nodest_conn` were set only system-wide. Also apply them
for new `lb_*` and `ingress_sbox` sandboxes, so they are appropriately
propagated