### PR TITLE
portmapper: do not run dummy proxy when requesting a specific port

### DIFF
--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -78,7 +78,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 			if err != nil {
 				return nil, err
 			}
-		} else {
+		} else if hostPortStart != hostPortEnd {
 			m.userlandProxy, err = newDummyProxy(proto, hostIP, allocatedHostPort)
 			if err != nil {
 				return nil, err
@@ -101,7 +101,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 			if err != nil {
 				return nil, err
 			}
-		} else {
+		} else if hostPortStart != hostPortEnd {
 			m.userlandProxy, err = newDummyProxy(proto, hostIP, allocatedHostPort)
 			if err != nil {
 				return nil, err
@@ -128,7 +128,7 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 			if err != nil {
 				return nil, err
 			}
-		} else {
+		} else if hostPortStart != hostPortEnd {
 			m.userlandProxy, err = newDummyProxy(proto, hostIP, allocatedHostPort)
 			if err != nil {
 				return nil, err
@@ -166,11 +166,13 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 		return nil
 	}
 
-	if err := m.userlandProxy.Start(); err != nil {
-		if err := cleanup(); err != nil {
-			return nil, fmt.Errorf("Error during port allocation cleanup: %v", err)
+	if m.userlandProxy != nil {
+		if err := m.userlandProxy.Start(); err != nil {
+			if err := cleanup(); err != nil {
+				return nil, fmt.Errorf("Error during port allocation cleanup: %v", err)
+			}
+			return nil, err
 		}
-		return nil, err
 	}
 
 	pm.currentMappings[key] = m


### PR DESCRIPTION
When a specific port is requested, we do not start a dummy proxy to
mark the port not available anymore. Doing so trigger numerous
problems, notably with UDP.

 - moby/moby#28589
 - moby/moby#8795
 - #2423

This change requires altering tests. It also becomes possible to map
to a port already used by the host, shadowing it. There is also the
possibility of using a port in the dynamic range which is already in
use by the host (but this case was not handled gracefully either,
making the whole allocation fails instead of trying the next port).

Alternatively, the change could be done only for UDP where the problem
is more apparent. Or it could be configurable.

Cc moby/moby#14856