### PR TITLE
[20.10] Apply peformance tuning to new sandboxes also

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -1175,6 +1175,14 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 
 	if sb.osSbox != nil {
 		// Apply operating specific knobs on the load balancer sandbox
+		err := sb.osSbox.InvokeFunc(func() {
+			sb.osSbox.ApplyOSTweaks(sb.oslTypes)
+		})
+
+		if err != nil {
+			logrus.Errorf("Failed to apply performance tuning sysctls to the sandbox: %v", err)
+		}
+		// Keep this just so performance is not changed
 		sb.osSbox.ApplyOSTweaks(sb.oslTypes)
 	}
 

--- a/service_linux.go
+++ b/service_linux.go
@@ -169,6 +169,10 @@ func (n *network) addLBBackend(ip net.IP, lb *loadBalancer) {
 	if err := i.NewDestination(s, d); err != nil && err != syscall.EEXIST {
 		logrus.Errorf("Failed to create real server %s for vip %s fwmark %d in sbox %.7s (%.7s): %v", ip, lb.vip, lb.fwMark, sb.ID(), sb.ContainerID(), err)
 	}
+
+	// Ensure that kernel tweaks are applied in case this is the first time
+	// we've initialized ip_vs
+	sb.osSbox.ApplyOSTweaks(sb.oslTypes)
 }
 
 // Remove loadbalancer backend the load balancing endpoint for this


### PR DESCRIPTION
Pull https://github.com/moby/moby/pull/43146 and
https://github.com/moby/moby/pull/43670 into 20.10

relates to #35082, moby/libnetwork#2491

Previously, values for expire_quiescent_template, conn_reuse_mode,
and expire_nodest_conn were set only system-wide. Also apply them
for new lb_* and ingress_sbox sandboxes, so they are appropriately
propagated

Signed-off-by: Ryan Barry <rbarry@mirantis.com>