### PR TITLE
[20.10] libnetwork: skip firewalld management for rootless

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/rootless"
 	"github.com/sirupsen/logrus"
 )
 
@@ -102,6 +103,12 @@ func probe() {
 }
 
 func initFirewalld() {
+	// When running with RootlessKit, firewalld is running as the root outside our network namespace
+	// https://github.com/moby/moby/issues/43781
+	if rootless.RunningWithRootlessKit() {
+		logrus.Info("skipping firewalld management for rootless mode")
+		return
+	}
 	if err := FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}

--- a/vendor/github.com/docker/docker/rootless/rootless.go
+++ b/vendor/github.com/docker/docker/rootless/rootless.go
@@ -1,0 +1,25 @@
+package rootless // import "github.com/docker/docker/rootless"
+
+import (
+	"os"
+	"sync"
+)
+
+const (
+	// RootlessKitDockerProxyBinary is the binary name of rootlesskit-docker-proxy
+	RootlessKitDockerProxyBinary = "rootlesskit-docker-proxy"
+)
+
+var (
+	runningWithRootlessKit     bool
+	runningWithRootlessKitOnce sync.Once
+)
+
+// RunningWithRootlessKit returns true if running under RootlessKit namespaces.
+func RunningWithRootlessKit() bool {
+	runningWithRootlessKitOnce.Do(func() {
+		u := os.Getenv("ROOTLESSKIT_STATE_DIR")
+		runningWithRootlessKit = u != ""
+	})
+	return runningWithRootlessKit
+}


### PR DESCRIPTION
Fix moby/moby#43781

"Cherry-pick" https://github.com/moby/moby/pull/43793

> **- What I did** Fix:
> 
> * [No networking in rootless docker with firewalld #43781](https://github.com/moby/moby/issues/43781)
> 
> **- How I did it**
> 
> Skip firewalld management when running with RootlessKit
> 
> **- How to verify it**
> 
> ```
> sudo systemctl enable firewalld
> dockerd-rootless-setuptool.sh install -f
> docker --context=rootless run --rm alpine sh -euxc 'apk add neofetch && neofetch'
> ```
> 
> **- Description for the changelog**
> 
> libnetwork: skip firewalld management for rootless
> 
> **- A picture of a cute animal (not mandatory but encouraged)** 
> 🐧


