### PR TITLE
delete minor unreachable code caused by t.Fatalf

### DIFF
--- a/ipam/parallel_test.go
+++ b/ipam/parallel_test.go
@@ -212,7 +212,6 @@ func allocate(t *testing.T, tctx *testContext, parallel int64) {
 		}
 		if there, ok := tctx.ipMap[ip.String()]; ok && there {
 			t.Fatalf("Got duplicate IP %s", ip.String())
-			break
 		}
 		tctx.ipList = append(tctx.ipList, ip)
 		tctx.ipMap[ip.String()] = true


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

> **Warning**
> libnetwork was moved to https://github.com/moby/moby/tree/master/libnetwork
>
> libnetwork has been merged to the main repo of Moby since Docker 22.06.
>
> The old libnetwork repo (https://github.com/moby/libnetwork) now only accepts PR for Docker 20.10,
> and will be archived after the EOL of Docker 20.10.
