### PR TITLE
Revert: Added API to set ephemeral port allocator range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -14,7 +13,6 @@ import (
 	"github.com/docker/libnetwork/ipamutils"
 	"github.com/docker/libnetwork/netlabel"
 	"github.com/docker/libnetwork/osl"
-	"github.com/docker/libnetwork/portallocator"
 	"github.com/sirupsen/logrus"
 )
 
@@ -237,23 +235,6 @@ func OptionExperimental(exp bool) Option {
 	return func(c *Config) {
 		logrus.Debugf("Option Experimental: %v", exp)
 		c.Daemon.Experimental = exp
-	}
-}
-
-// OptionDynamicPortRange function returns an option setter for service port allocation range
-func OptionDynamicPortRange(in string) Option {
-	return func(c *Config) {
-		start, end := 0, 0
-		if len(in) > 0 {
-			n, err := fmt.Sscanf(in, "%d-%d", &start, &end)
-			if n != 2 || err != nil {
-				logrus.Errorf("Failed to parse range string with err %v", err)
-				return
-			}
-		}
-		if err := portallocator.Get().SetPortRange(start, end); err != nil {
-			logrus.Errorf("Failed to set port range with err %v", err)
-		}
 	}
 }
 

--- a/portallocator/portallocator_test.go
+++ b/portallocator/portallocator_test.go
@@ -1,7 +1,6 @@
 package portallocator
 
 import (
-	"fmt"
 	"net"
 	"testing"
 
@@ -320,49 +319,5 @@ func TestNoDuplicateBPR(t *testing.T) {
 		t.Fatal(err)
 	} else if port == p.Begin {
 		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)
-	}
-}
-
-func TestChangePortRange(t *testing.T) {
-	var tests = []struct {
-		begin  int
-		end    int
-		setErr error
-		reqRlt int
-	}{
-		{defaultPortRangeEnd + 1, defaultPortRangeEnd + 10, fmt.Errorf("begin out of range"), 0},
-		{defaultPortRangeStart - 10, defaultPortRangeStart - 1, fmt.Errorf("end out of range"), 0},
-		{defaultPortRangeEnd, defaultPortRangeStart, fmt.Errorf("out of order"), 0},
-		{defaultPortRangeStart + 100, defaultPortRangeEnd + 10, nil, defaultPortRangeStart + 100},
-		{0, 0, nil, defaultPortRangeStart}, // revert to default if no value given
-		{defaultPortRangeStart - 100, defaultPortRangeEnd, nil, defaultPortRangeStart + 1},
-	}
-	p := Get()
-	port := 0
-	for _, c := range tests {
-		t.Logf("test: port allocate range %v-%v, setErr=%v, reqPort=%v",
-			c.begin, c.end, c.setErr, c.reqRlt)
-		err := p.SetPortRange(c.begin, c.end)
-		if (c.setErr == nil && c.setErr != err) ||
-			(c.setErr != nil && err == nil) {
-			t.Fatalf("Unexpected set range result, expected=%v, actual=%v", c.setErr, err)
-		}
-		if err != nil {
-			continue
-		}
-		if port > 0 {
-			err := p.ReleasePort(defaultIP, "tcp", port)
-			if err != nil {
-				t.Fatalf("Releasing port %v failed, err=%v", port, err)
-			}
-		}
-
-		port, err = p.RequestPort(defaultIP, "tcp", 0)
-		if err != nil {
-			t.Fatalf("Request failed, err %v", err)
-		}
-		if port != c.reqRlt {
-			t.Fatalf("Incorrect port returned, expected=%v, actual=%v", c.reqRlt, port)
-		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

> **Warning**
> libnetwork was moved to https://github.com/moby/moby/tree/master/libnetwork
>
> libnetwork has been merged to the main repo of Moby since Docker 22.06.
>
> The old libnetwork repo (https://github.com/moby/libnetwork) now only accepts PR for Docker 20.10,
> and will be archived after the EOL of Docker 20.10.

Reference Issue : https://github.com/moby/moby/issues/44423

This PR backports the current behavior in moby/moby to 20.10.  The PR for master is [#43066](https://github.com/moby/moby/pull/43066)

### Testing
Ran `make` and `make unit-tests`.  The unit tests had one failure that also exists in the master branch

```
--- FAIL: TestDNSOptions (0.16s)
    service_common_test.go:65: assertion failed: expected [timeout:2 attempts:5 ndots:0] (length 3) to have length 1
    service_common_test.go:66: assertion failed: ndots:0 (string) != timeout:2 (dnsOptionsList[0] string)
```