### PR TITLE
BACKPORT: libnetwork: processEndpointCreate: Fix deadlock between getSvcRecords and processEndpointCreate

### DIFF
--- a/store.go
+++ b/store.go
@@ -340,8 +340,11 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 		return
 	}
 
+	networkID := n.ID()
+	endpointID := ep.ID()
+
 	c.Lock()
-	nw, ok := nmap[n.ID()]
+	nw, ok := nmap[networkID]
 	c.Unlock()
 
 	if ok {
@@ -349,12 +352,12 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 		n.updateSvcRecord(ep, c.getLocalEps(nw), true)
 
 		c.Lock()
-		nw.localEps[ep.ID()] = ep
+		nw.localEps[endpointID] = ep
 
 		// If we had learned that from the kv store remove it
 		// from remote ep list now that we know that this is
 		// indeed a local endpoint
-		delete(nw.remoteEps, ep.ID())
+		delete(nw.remoteEps, endpointID)
 		c.Unlock()
 		return
 	}
@@ -370,8 +373,8 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 	n.updateSvcRecord(ep, c.getLocalEps(nw), true)
 
 	c.Lock()
-	nw.localEps[ep.ID()] = ep
-	nmap[n.ID()] = nw
+	nw.localEps[endpointID] = ep
+	nmap[networkID] = nw
 	nw.stopCh = make(chan struct{})
 	c.Unlock()
 


### PR DESCRIPTION
References https://github.com/moby/moby/pull/42545

> **Warning**
> libnetwork was moved to https://github.com/moby/moby/tree/master/libnetwork
>
> libnetwork has been merged to the main repo of Moby since Docker 22.06.
>
> The old libnetwork repo (https://github.com/moby/libnetwork) now only accepts PR for Docker 20.10,
> and will be archived after the EOL of Docker 20.10.

reference PR: https://github.com/moby/moby/pull/42545

I've attempted to preserve the original author of the commit for full credit to them for the solution in this PR.

One person commented in the PR that they are hitting this on 20.10; I am also hitting this issue on 20.10.10 and it would be amazing if this could be merged and included in the next v20 point release!

Please let me know if there is anything I can do to help get this merged and included in the next point release.
