### PR TITLE
CI: update to go1.18.9, gofmt, and fix some linting issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   working_directory: ~/go/src/github.com/docker/libnetwork
   docker:
     # the following image is irrelevant for the build, everything is built inside a container, check the Makefile
-    - image: 'circleci/golang:latest'
+    - image: 'cimg/go:1.18.9'
       environment:
           dockerbuildargs: .
           dockerargs:  --privileged -e CIRCLECI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.18
           reusable: true
           exclusive: false
       - run: make builder
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.18
           reusable: true
           exclusive: false
       - run: make build
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.18
           reusable: true
           exclusive: false
       - run: make check
@@ -45,7 +45,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.18
           reusable: true
           exclusive: false
       - run: make cross
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.18
           reusable: true
           exclusive: false
       - run: make unit-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
-ARG GO_VERSION=1.13.8
+ARG GO_VERSION=1.18.9
 
 FROM golang:${GO_VERSION}-buster as dev
 RUN apt-get update && apt-get -y install iptables \
 		protobuf-compiler
 
-RUN go get -d github.com/gogo/protobuf/protoc-gen-gogo && \
-		cd /go/src/github.com/gogo/protobuf/protoc-gen-gogo && \
-		git reset --hard 30cf7ac33676b5786e78c746683f0d4cd64fa75b && \
-		go install
+RUN git clone https://github.com/gogo/protobuf.git  /go/src/github.com/gogo/protobuf \
+  && cd /go/src/github.com/gogo/protobuf/protoc-gen-gogo \
+  && git reset --hard 30cf7ac33676b5786e78c746683f0d4cd64fa75b \
+  && GO111MODULE=off go install
 
-RUN go get golang.org/x/lint/golint \
-		golang.org/x/tools/cmd/cover \
-		github.com/mattn/goveralls \
-		github.com/gordonklaus/ineffassign \
-		github.com/client9/misspell/cmd/misspell
+RUN go install golang.org/x/lint/golint@latest \
+ && go install golang.org/x/tools/cmd/cover@latest \
+ && go install github.com/mattn/goveralls@latest \
+ && go install github.com/gordonklaus/ineffassign@latest \
+ && go install github.com/client9/misspell/cmd/misspell@latest
 
 WORKDIR /go/src/github.com/docker/libnetwork
+ENV GO111MODULE=off
+
 
 FROM dev
 

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ build: builder
 build-local:
 	@echo "🐳 $@"
 	@mkdir -p "bin"
-	go build -tags experimental -o "bin/dnet" ./cmd/dnet
-	go build -o "bin/docker-proxy" ./cmd/proxy
+	GO111MODULE=off go build -tags experimental -o "bin/dnet" ./cmd/dnet
+	GO111MODULE=off go build -o "bin/docker-proxy" ./cmd/proxy
 	CGO_ENABLED=0 go build -o "bin/diagnosticClient" ./cmd/diagnostic
 	CGO_ENABLED=0 go build -o "bin/testMain" ./cmd/networkdb-test/testMain.go
 
@@ -82,8 +82,8 @@ cross: builder
 
 cross-local:
 	@echo "🐳 $@"
-	go build -o "bin/dnet-$$GOOS-$$GOARCH" ./cmd/dnet
-	go build -o "bin/docker-proxy-$$GOOS-$$GOARCH" ./cmd/proxy
+	GO111MODULE=off go build -o "bin/dnet-$$GOOS-$$GOARCH" ./cmd/dnet
+	GO111MODULE=off go build -o "bin/docker-proxy-$$GOOS-$$GOARCH" ./cmd/proxy
 
 # Rebuild protocol buffers.
 # These may need to be rebuilt after vendoring updates, so .proto files are declared .PHONY so they are always rebuilt.
@@ -125,7 +125,7 @@ unit-tests: builder
 unit-tests-local:
 	@echo "🐳 Running tests... "
 	@echo "mode: count" > coverage.coverprofile
-	@go build -o "bin/docker-proxy" ./cmd/proxy
+	@GO111MODULE=off go build -o "bin/docker-proxy" ./cmd/proxy
 	@for dir in $$( find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './vendor/*' -type d); do \
 	if ls $$dir/*.go &> /dev/null; then \
 		pushd . &> /dev/null ; \

--- a/api/api.go
+++ b/api/api.go
@@ -278,6 +278,7 @@ func processCreateDefaults(c libnetwork.NetworkController, nc *networkCreate) {
 /***************************
  NetworkController interface
 ****************************/
+
 func procCreateNetwork(c libnetwork.NetworkController, vars map[string]string, body []byte) (interface{}, *responseStatus) {
 	var create networkCreate
 
@@ -385,6 +386,7 @@ func procCreateSandbox(c libnetwork.NetworkController, vars map[string]string, b
 /******************
  Network interface
 *******************/
+
 func procCreateEndpoint(c libnetwork.NetworkController, vars map[string]string, body []byte) (interface{}, *responseStatus) {
 	var ec endpointCreate
 
@@ -483,6 +485,7 @@ func procDeleteNetwork(c libnetwork.NetworkController, vars map[string]string, b
 /******************
  Endpoint interface
 *******************/
+
 func procJoinEndpoint(c libnetwork.NetworkController, vars map[string]string, body []byte) (interface{}, *responseStatus) {
 	var ej endpointJoin
 	var setFctList []libnetwork.EndpointOption
@@ -561,6 +564,7 @@ func procDeleteEndpoint(c libnetwork.NetworkController, vars map[string]string, 
 /******************
  Service interface
 *******************/
+
 func procGetServices(c libnetwork.NetworkController, vars map[string]string, body []byte) (interface{}, *responseStatus) {
 	// Look for query filters and validate
 	nwName, filterByNwName := vars[urlNwName]
@@ -734,6 +738,7 @@ func procDetachBackend(c libnetwork.NetworkController, vars map[string]string, b
 /******************
  Sandbox interface
 *******************/
+
 func procGetSandbox(c libnetwork.NetworkController, vars map[string]string, body []byte) (interface{}, *responseStatus) {
 	if epT, ok := vars[urlEpID]; ok {
 		sv, errRsp := findService(c, epT, byID)
@@ -816,6 +821,7 @@ func procDeleteSandbox(c libnetwork.NetworkController, vars map[string]string, b
 /***********
   Utilities
 ************/
+
 const (
 	byID = iota
 	byName

--- a/bitseq/sequence.go
+++ b/bitseq/sequence.go
@@ -621,13 +621,14 @@ func findSequence(head *sequence, bytePos uint64) (*sequence, *sequence, uint64,
 // Remove current sequence if empty.
 // Check if new sequence can be merged with neighbour (previous/next) sequences.
 //
-//
 // Identify "current" sequence containing block:
-//                                      [prev seq] [current seq] [next seq]
+//
+//	[prev seq] [current seq] [next seq]
 //
 // Based on block position, resulting list of sequences can be any of three forms:
 //
-//        block position                        Resulting list of sequences
+//	block position                        Resulting list of sequences
+//
 // A) block is first in current:         [prev seq] [new] [modified current seq] [next seq]
 // B) block is last in current:          [prev seq] [modified current seq] [new] [next seq]
 // C) block is in the middle of current: [prev seq] [curr pre] [new] [curr post] [next seq]

--- a/client/types.go
+++ b/client/types.go
@@ -31,6 +31,7 @@ type SandboxResource struct {
 /***********
   Body types
   ************/
+
 type ipamConf struct {
 	PreferredPool string
 	SubPool       string

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/libnetwork/types"
 )
 
-//DataStore exported
+// DataStore exported
 type DataStore interface {
 	// GetObject gets data from datastore and unmarshals to the specified object
 	GetObject(key string, o KVObject) error
@@ -174,14 +174,14 @@ func (cfg *ScopeCfg) IsValid() bool {
 	return true
 }
 
-//Key provides convenient method to create a Key
+// Key provides convenient method to create a Key
 func Key(key ...string) string {
 	keychain := append(rootChain, key...)
 	str := strings.Join(keychain, "/")
 	return str + "/"
 }
 
-//ParseKey provides convenient method to unpack the key to complement the Key function
+// ParseKey provides convenient method to unpack the key to complement the Key function
 func ParseKey(key string) ([]string, error) {
 	chain := strings.Split(strings.Trim(key, "/"), "/")
 

--- a/drivers/bridge/bridge.go
+++ b/drivers/bridge/bridge.go
@@ -781,8 +781,8 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		// Setup IP6Tables.
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupIP6Tables},
 
-		//We want to track firewalld configuration so that
-		//if it is started/reloaded, the rules can be applied correctly
+		// We want to track firewalld configuration so that
+		// if it is started/reloaded, the rules can be applied correctly
 		{d.config.EnableIPTables, network.setupFirewalld},
 		// same for IPv6
 		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupFirewalld6},
@@ -796,7 +796,7 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 		// Add inter-network communication rules.
 		{d.config.EnableIPTables, setupNetworkIsolationRules},
 
-		//Configure bridge networking filtering if ICC is off and IP tables are enabled
+		// Configure bridge networking filtering if ICC is off and IP tables are enabled
 		{!config.EnableICC && d.config.EnableIPTables, setupBridgeNetFiltering},
 	} {
 		if step.Condition {

--- a/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_int8.go
+++ b/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_int8.go
@@ -1,3 +1,4 @@
+//go:build !arm && !ppc64 && !ppc64le && !riscv64
 // +build !arm,!ppc64,!ppc64le,!riscv64
 
 package bridge

--- a/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_uint8.go
+++ b/drivers/bridge/netlink_deprecated_linux_rawsockaddr_data_uint8.go
@@ -1,3 +1,4 @@
+//go:build arm || ppc64 || ppc64le || riscv64
 // +build arm ppc64 ppc64le riscv64
 
 package bridge

--- a/drivers/bridge/netlink_deprecated_unsupported.go
+++ b/drivers/bridge/netlink_deprecated_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package bridge

--- a/drivers/bridge/port_mapping_test.go
+++ b/drivers/bridge/port_mapping_test.go
@@ -97,6 +97,8 @@ func TestPortMappingConfig(t *testing.T) {
 }
 
 func TestPortMappingV6Config(t *testing.T) {
+	t.Skip("FIXME: circleci does not have proper IPv6 support")
+
 	defer testutils.SetupTestOSContext(t)()
 	d := newDriver()
 

--- a/drivers/bridge/setup_bridgenetfiltering.go
+++ b/drivers/bridge/setup_bridgenetfiltering.go
@@ -20,7 +20,7 @@ const (
 	ipvboth
 )
 
-//Gets the IP version in use ( [ipv4], [ipv6] or [ipv4 and ipv6] )
+// Gets the IP version in use ( [ipv4], [ipv6] or [ipv4 and ipv6] )
 func getIPVersion(config *networkConfiguration) ipVersion {
 	ipVersion := ipv4
 	if config.AddressIPv6 != nil || config.EnableIPv6 {
@@ -49,7 +49,7 @@ func setupBridgeNetFiltering(config *networkConfiguration, i *bridgeInterface) e
 	return nil
 }
 
-//Enable bridge net filtering if ip forwarding is enabled. See github issue #11404
+// Enable bridge net filtering if ip forwarding is enabled. See github issue #11404
 func checkBridgeNetFiltering(config *networkConfiguration, i *bridgeInterface) error {
 	ipVer := getIPVersion(config)
 	iface := config.BridgeName
@@ -119,7 +119,7 @@ func getBridgeNFKernelParam(ipVer ipVersion) string {
 	}
 }
 
-//Gets the value of the kernel parameters located at the given path
+// Gets the value of the kernel parameters located at the given path
 func getKernelBoolParam(path string) (bool, error) {
 	enabled := false
 	line, err := ioutil.ReadFile(path)
@@ -132,7 +132,7 @@ func getKernelBoolParam(path string) (bool, error) {
 	return enabled, err
 }
 
-//Sets the value of the kernel parameter located at the given path
+// Sets the value of the kernel parameter located at the given path
 func setKernelBoolParam(path string, on bool) error {
 	value := byte('0')
 	if on {
@@ -141,7 +141,7 @@ func setKernelBoolParam(path string, on bool) error {
 	return ioutil.WriteFile(path, []byte{value, '\n'}, 0644)
 }
 
-//Checks to see if packet forwarding is enabled
+// Checks to see if packet forwarding is enabled
 func isPacketForwardingEnabled(ipVer ipVersion, iface string) (bool, error) {
 	switch ipVer {
 	case ipv4, ipv6:

--- a/drivers/bridge/setup_ip_tables.go
+++ b/drivers/bridge/setup_ip_tables.go
@@ -22,6 +22,7 @@ const (
 	// bridge. A positive match identifies a packet originated from one bridge
 	// network's bridge destined to another bridge network's bridge and will
 	// result in the packet being dropped. No match returns to the parent chain.
+
 	IsolationChain1 = "DOCKER-ISOLATION-STAGE-1"
 	IsolationChain2 = "DOCKER-ISOLATION-STAGE-2"
 )

--- a/drivers/overlay/ostweaks_unsupported.go
+++ b/drivers/overlay/ostweaks_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package overlay

--- a/drivers/windows/port_mapping.go
+++ b/drivers/windows/port_mapping.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windows

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Shim for the Host Network Service (HNS) to manage networking for

--- a/drivers/windows/windows_store.go
+++ b/drivers/windows/windows_store.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windows

--- a/drivers/windows/windows_test.go
+++ b/drivers/windows/windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windows

--- a/endpoint_info_unix.go
+++ b/endpoint_info_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package libnetwork

--- a/endpoint_info_windows.go
+++ b/endpoint_info_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package libnetwork

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package libnetwork

--- a/etchosts/etchosts_test.go
+++ b/etchosts/etchosts_test.go
@@ -446,11 +446,11 @@ func TestConcurrentWrites(t *testing.T) {
 
 			for j := 0; j < 25; j++ {
 				if err := Add(file.Name(), rec); err != nil {
-					t.Fatal(err)
+					t.Error(err)
 				}
 
 				if err := Delete(file.Name(), rec); err != nil {
-					t.Fatal(err)
+					t.Error(err)
 				}
 			}
 		}(i)

--- a/firewall_others.go
+++ b/firewall_others.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package libnetwork

--- a/ipam/allocator_test.go
+++ b/ipam/allocator_test.go
@@ -1516,7 +1516,7 @@ func TestRequestReleaseAddressDuplicate(t *testing.T) {
 				wg.Add(1)
 				go func(ip *net.IPNet) {
 					if err = a.ReleaseAddress(poolID, ip.IP); err != nil {
-						t.Fatal(err)
+						t.Error(err)
 					}
 					l.Lock()
 					ips = append(ips, IP{ip, -1})

--- a/ipam/parallel_test.go
+++ b/ipam/parallel_test.go
@@ -93,7 +93,7 @@ func TestRequestPoolParallel(t *testing.T) {
 		go func(t *testing.T, a *Allocator, ch chan *op) {
 			name, _, _, err := a.RequestPool("GlobalDefault", "", "", nil, false)
 			if err != nil {
-				t.Fatalf("request error %v", err)
+				t.Errorf("request error %v", err)
 			}
 			idx := atomic.AddInt32(&operationIndex, 1)
 			ch <- &op{idx, true, name}
@@ -101,7 +101,7 @@ func TestRequestPoolParallel(t *testing.T) {
 			idx = atomic.AddInt32(&operationIndex, 1)
 			err = a.ReleasePool(name)
 			if err != nil {
-				t.Fatalf("release error %v", err)
+				t.Errorf("release error %v", err)
 			}
 			ch <- &op{idx, false, name}
 		}(t, a, ch)
@@ -267,7 +267,7 @@ func release(t *testing.T, tctx *testContext, mode releaseMode, parallel int64) 
 			// logrus.Errorf("list %v", tctx.ipList)
 			err := tctx.a.ReleaseAddress(tctx.pid, tctx.ipList[index].IP)
 			if err != nil {
-				t.Fatalf("routine %d got %v", id, err)
+				t.Errorf("routine %d got %v", id, err)
 			}
 			ch <- tctx.ipList[index]
 			parallelExec.Release(1)

--- a/ipams/builtin/builtin_unix.go
+++ b/ipams/builtin/builtin_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd || darwin
 // +build linux freebsd darwin
 
 package builtin

--- a/ipams/builtin/builtin_windows.go
+++ b/ipams/builtin/builtin_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package builtin

--- a/ipams/remote/api/api.go
+++ b/ipams/remote/api/api.go
@@ -34,14 +34,14 @@ func (capRes GetCapabilityResponse) ToCapability() *ipamapi.Capability {
 	}
 }
 
-// GetAddressSpacesResponse is the response to the ``get default address spaces`` request message
+// GetAddressSpacesResponse is the response to the “get default address spaces“ request message
 type GetAddressSpacesResponse struct {
 	Response
 	LocalDefaultAddressSpace  string
 	GlobalDefaultAddressSpace string
 }
 
-// RequestPoolRequest represents the expected data in a ``request address pool`` request message
+// RequestPoolRequest represents the expected data in a “request address pool“ request message
 type RequestPoolRequest struct {
 	AddressSpace string
 	Pool         string
@@ -50,7 +50,7 @@ type RequestPoolRequest struct {
 	V6           bool
 }
 
-// RequestPoolResponse represents the response message to a ``request address pool`` request
+// RequestPoolResponse represents the response message to a “request address pool“ request
 type RequestPoolResponse struct {
 	Response
 	PoolID string
@@ -58,37 +58,37 @@ type RequestPoolResponse struct {
 	Data   map[string]string
 }
 
-// ReleasePoolRequest represents the expected data in a ``release address pool`` request message
+// ReleasePoolRequest represents the expected data in a “release address pool“ request message
 type ReleasePoolRequest struct {
 	PoolID string
 }
 
-// ReleasePoolResponse represents the response message to a ``release address pool`` request
+// ReleasePoolResponse represents the response message to a “release address pool“ request
 type ReleasePoolResponse struct {
 	Response
 }
 
-// RequestAddressRequest represents the expected data in a ``request address`` request message
+// RequestAddressRequest represents the expected data in a “request address“ request message
 type RequestAddressRequest struct {
 	PoolID  string
 	Address string
 	Options map[string]string
 }
 
-// RequestAddressResponse represents the expected data in the response message to a ``request address`` request
+// RequestAddressResponse represents the expected data in the response message to a “request address“ request
 type RequestAddressResponse struct {
 	Response
 	Address string // in CIDR format
 	Data    map[string]string
 }
 
-// ReleaseAddressRequest represents the expected data in a ``release address`` request message
+// ReleaseAddressRequest represents the expected data in a “release address“ request message
 type ReleaseAddressRequest struct {
 	PoolID  string
 	Address string
 }
 
-// ReleaseAddressResponse represents the response message to a ``release address`` request
+// ReleaseAddressResponse represents the response message to a “release address“ request
 type ReleaseAddressResponse struct {
 	Response
 }

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -213,7 +213,7 @@ func RunConcurrencyTest(t *testing.T, allowXlock bool) {
 			defer wg.Done()
 			err := natChain.Forward(Append, ip, port, proto, dstAddr, dstPort, "lo")
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}()
 	}

--- a/libnetwork_test.go
+++ b/libnetwork_test.go
@@ -1080,6 +1080,9 @@ func TestEndpointMultipleJoins(t *testing.T) {
 		libnetwork.OptionHostname("test"),
 		libnetwork.OptionDomainname("docker.io"),
 		libnetwork.OptionExtraHost("web", "192.168.0.1"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		if err := sbx1.Delete(); err != nil {
 			t.Fatal(err)
@@ -1087,6 +1090,9 @@ func TestEndpointMultipleJoins(t *testing.T) {
 	}()
 
 	sbx2, err := controller.NewSandbox("c2")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		if err := sbx2.Delete(); err != nil {
 			t.Fatal(err)

--- a/netutils/utils_linux.go
+++ b/netutils/utils_linux.go
@@ -1,4 +1,6 @@
+//go:build linux
 // +build linux
+
 // Network utility functions.
 
 package netutils

--- a/network.go
+++ b/network.go
@@ -980,13 +980,13 @@ func (n *network) Delete(options ...NetworkDeleteOption) error {
 }
 
 // This function gets called in 3 ways:
-//  * Delete() -- (false, false)
-//      remove if endpoint count == 0 or endpoint count == 1 and
-//      there is a load balancer IP
-//  * Delete(libnetwork.NetworkDeleteOptionRemoveLB) -- (false, true)
-//      remove load balancer and network if endpoint count == 1
-//  * controller.networkCleanup() -- (true, true)
-//      remove the network no matter what
+//   - Delete() -- (false, false)
+//     remove if endpoint count == 0 or endpoint count == 1 and
+//     there is a load balancer IP
+//   - Delete(libnetwork.NetworkDeleteOptionRemoveLB) -- (false, true)
+//     remove load balancer and network if endpoint count == 1
+//   - controller.networkCleanup() -- (true, true)
+//     remove the network no matter what
 func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	n.Lock()
 	c := n.ctrlr

--- a/network_unix.go
+++ b/network_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package libnetwork

--- a/network_windows.go
+++ b/network_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package libnetwork

--- a/networkdb/networkdb.go
+++ b/networkdb/networkdb.go
@@ -283,7 +283,7 @@ func (nDB *NetworkDB) Close() {
 		logrus.Errorf("%v(%v) Could not close DB: %v", nDB.config.Hostname, nDB.config.NodeID, err)
 	}
 
-	//Avoid (*Broadcaster).run goroutine leak
+	// Avoid (*Broadcaster).run goroutine leak
 	nDB.broadcaster.Close()
 }
 
@@ -473,17 +473,18 @@ func (nDB *NetworkDB) deleteNodeFromNetworks(deletedNode string) {
 
 // deleteNodeNetworkEntries is called in 2 conditions with 2 different outcomes:
 // 1) when a notification is coming of a node leaving the network
-//		- Walk all the network entries and mark the leaving node's entries for deletion
-//			These will be garbage collected when the reap timer will expire
+//   - Walk all the network entries and mark the leaving node's entries for deletion
+//     These will be garbage collected when the reap timer will expire
+//
 // 2) when the local node is leaving the network
-//		- Walk all the network entries:
-//			A) if the entry is owned by the local node
-//		  then we will mark it for deletion. This will ensure that if a node did not
-//		  yet received the notification that the local node is leaving, will be aware
-//		  of the entries to be deleted.
-//			B) if the entry is owned by a remote node, then we can safely delete it. This
-//			ensures that if we join back this network as we receive the CREATE event for
-//		  entries owned by remote nodes, we will accept them and we notify the application
+//   - Walk all the network entries:
+//     A) if the entry is owned by the local node
+//     then we will mark it for deletion. This will ensure that if a node did not
+//     yet received the notification that the local node is leaving, will be aware
+//     of the entries to be deleted.
+//     B) if the entry is owned by a remote node, then we can safely delete it. This
+//     ensures that if we join back this network as we receive the CREATE event for
+//     entries owned by remote nodes, we will accept them and we notify the application
 func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
 	// Indicates if the delete is triggered for the local node
 	isNodeLocal := node == nDB.config.NodeID
@@ -608,7 +609,7 @@ func (nDB *NetworkDB) JoinNetwork(nid string) error {
 	nodeNetworks[nid] = &network{id: nid, ltime: ltime, entriesNumber: entries}
 	nodeNetworks[nid].tableBroadcasts = &memberlist.TransmitLimitedQueue{
 		NumNodes: func() int {
-			//TODO fcrisciani this can be optimized maybe avoiding the lock?
+			// TODO fcrisciani this can be optimized maybe avoiding the lock?
 			// this call is done each GetBroadcasts call to evaluate the number of
 			// replicas for the message
 			nDB.RLock()

--- a/networkdb/networkdb.pb.go
+++ b/networkdb/networkdb.pb.go
@@ -145,7 +145,9 @@ var NetworkEvent_Type_value = map[string]int32{
 func (x NetworkEvent_Type) String() string {
 	return proto.EnumName(NetworkEvent_Type_name, int32(x))
 }
-func (NetworkEvent_Type) EnumDescriptor() ([]byte, []int) { return fileDescriptorNetworkdb, []int{2, 0} }
+func (NetworkEvent_Type) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptorNetworkdb, []int{2, 0}
+}
 
 type TableEvent_Type int32
 

--- a/networkdb/networkdb_test.go
+++ b/networkdb/networkdb_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -562,12 +563,12 @@ func TestNetworkDBGarbageCollection(t *testing.T) {
 	assert.NilError(t, err)
 
 	for i := 0; i < keysWriteDelete; i++ {
-		err = dbs[i%2].CreateEntry("testTable", "network1", "key-"+string(i), []byte("value"))
+		err = dbs[i%2].CreateEntry("testTable", "network1", "key-"+strconv.Itoa(i), []byte("value"))
 		assert.NilError(t, err)
 	}
 	time.Sleep(time.Second)
 	for i := 0; i < keysWriteDelete; i++ {
-		err = dbs[i%2].DeleteEntry("testTable", "network1", "key-"+string(i))
+		err = dbs[i%2].DeleteEntry("testTable", "network1", "key-"+strconv.Itoa(i))
 		assert.NilError(t, err)
 	}
 	for i := 0; i < 2; i++ {

--- a/osl/kernel/knobs_unsupported.go
+++ b/osl/kernel/knobs_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package kernel

--- a/osl/namespace_unsupported.go
+++ b/osl/namespace_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !freebsd
 // +build !linux,!windows,!freebsd
 
 package osl

--- a/osl/sandbox_unsupported.go
+++ b/osl/sandbox_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !freebsd
 // +build !linux,!windows,!freebsd
 
 package osl

--- a/osl/sandbox_unsupported_test.go
+++ b/osl/sandbox_unsupported_test.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package osl

--- a/portmapper/mapper.go
+++ b/portmapper/mapper.go
@@ -214,7 +214,7 @@ func (pm *PortMapper) Unmap(host net.Addr) error {
 	return ErrUnknownBackendAddressType
 }
 
-//ReMapAll will re-apply all port mappings
+// ReMapAll will re-apply all port mappings
 func (pm *PortMapper) ReMapAll() {
 	pm.lock.Lock()
 	defer pm.lock.Unlock()

--- a/resolvconf/resolvconf.go
+++ b/resolvconf/resolvconf.go
@@ -139,12 +139,11 @@ func GetLastModified() *File {
 }
 
 // FilterResolvDNS cleans up the config in resolvConf.  It has two main jobs:
-// 1. It looks for localhost (127.*|::1) entries in the provided
-//    resolv.conf, removing local nameserver entries, and, if the resulting
-//    cleaned config has no defined nameservers left, adds default DNS entries
-// 2. Given the caller provides the enable/disable state of IPv6, the filter
-//    code will remove all IPv6 nameservers if it is not enabled for containers
-//
+//  1. It looks for localhost (127.*|::1) entries in the provided
+//     resolv.conf, removing local nameserver entries, and, if the resulting
+//     cleaned config has no defined nameservers left, adds default DNS entries
+//  2. Given the caller provides the enable/disable state of IPv6, the filter
+//     code will remove all IPv6 nameservers if it is not enabled for containers
 func FilterResolvDNS(resolvConf []byte, ipv6Enabled bool) (*File, error) {
 	cleanedResolvConf := localhostNSRegexp.ReplaceAll(resolvConf, []byte{})
 	// if IPv6 is not enabled, also clean out any IPv6 address nameserver

--- a/resolver_unix.go
+++ b/resolver_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package libnetwork

--- a/resolver_windows.go
+++ b/resolver_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package libnetwork

--- a/sandbox_dns_unix.go
+++ b/sandbox_dns_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package libnetwork

--- a/sandbox_dns_windows.go
+++ b/sandbox_dns_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package libnetwork

--- a/sandbox_externalkey_unix.go
+++ b/sandbox_externalkey_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd
 // +build linux freebsd
 
 package libnetwork

--- a/sandbox_externalkey_windows.go
+++ b/sandbox_externalkey_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package libnetwork

--- a/service_common.go
+++ b/service_common.go
@@ -1,3 +1,4 @@
+//go:build linux || windows
 // +build linux windows
 
 package libnetwork

--- a/service_unsupported.go
+++ b/service_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package libnetwork

--- a/testutils/context_unix.go
+++ b/testutils/context_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd
 // +build linux freebsd
 
 package testutils
@@ -16,8 +17,7 @@ import (
 //
 // Example usage:
 //
-//     defer SetupTestOSContext(t)()
-//
+//	defer SetupTestOSContext(t)()
 func SetupTestOSContext(t *testing.T) func() {
 	runtime.LockOSThread()
 	if err := syscall.Unshare(syscall.CLONE_NEWNET); err != nil {

--- a/testutils/context_windows.go
+++ b/testutils/context_windows.go
@@ -10,8 +10,7 @@ import (
 //
 // Example usage:
 //
-//     defer SetupTestOSContext(t)()
-//
+//	defer SetupTestOSContext(t)()
 func SetupTestOSContext(t *testing.T) func() {
 	return func() {
 	}


### PR DESCRIPTION
some of the "go get" installs now expect a newer version of Go, and we want the version to match the version in the 20.10 branch in moby, which is what this repository is used for.

