### PR TITLE
Clean up inDelete network atomically

### DIFF
--- a/network.go
+++ b/network.go
@@ -1064,9 +1064,6 @@ func (n *network) delete(force bool, rmLBEndpoint bool) error {
 	}
 
 	n.ipamRelease()
-	if err = c.updateToStore(n); err != nil {
-		logrus.Warnf("Failed to update store after ipam release for network %s (%s): %v", n.Name(), n.ID(), err)
-	}
 
 	// We are about to delete the network. Leave the gossip
 	// cluster for the network to stop all incoming network


### PR DESCRIPTION
- 20.10 backport of https://github.com/moby/moby/pull/45310

The `(*network).ipamRelease` function nils out the network's IPAM info fields, putting the network struct into an inconsistent state. The network-restore startup code panics if it tries to restore a network from a struct which has fewer IPAM config entries than IPAM info entries. Therefore `(*network).delete` contains a critical section: by persisting the network to the store after `ipamRelease()`, the datastore will contain an inconsistent network until the deletion operation completes and finishes deleting the network from the datastore. If for any reason the deletion operation is interrupted between `ipamRelease()` and `deleteFromStore()`, the daemon will crash on startup when it tries to restore the network.

Updating the datastore after releasing the network's IPAM pools may have served a purpose in the past, when a global datastore was used for intra-cluster communication and the IPAM allocator had persistent global state, but nowadays there is no global datastore and the IPAM allocator has no persistent state whatsoever. Remove the vestigial datastore update as it is no longer necessary and only serves to cause problems. If the network deletion is interrupted before the network is deleted from the datastore, the deletion will resume during the next daemon startup, including releasing the IPAM pools.

(cherry picked from commit moby/moby@c957ad006747df00730ce3aeaf4ac9df14baa998)
